### PR TITLE
Add a Signal trait for working with Iterators that yield Frames. Correct signal addition logic for unsigned Sample types.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,7 +1,7 @@
 //! This module provides various helper functions for performing operations on slices of frames.
 
 use {
-    Amplitude, Duplex, Frame, Sample,
+    Frame, Sample, FloatSample, SelectFloat,
     ToSampleSlice, ToSampleSliceMut, ToFrameSlice, ToFrameSliceMut,
     FromSampleSlice, FromSampleSliceMut, FromFrameSlice, FromFrameSliceMut,
 };
@@ -264,7 +264,7 @@ pub fn write<F>(a: &mut [F], b: &[F])
 pub fn add_in_place<F>(a: &mut [F], b: &[F])
     where F: Frame,
 {
-    zip_map_in_place(a, b, |a, b| a.add(b));
+    zip_map_in_place(a, b, |a, b| a.add_frame(b));
 }
 
 /// Scale the amplitude of each frame in `b` by `amp_per_channel` before summing it onto `a`.
@@ -272,10 +272,10 @@ pub fn add_in_place<F>(a: &mut [F], b: &[F])
 pub fn add_in_place_with_amp_per_channel<F, A>(a: &mut [F], b: &[F], amp_per_channel: A)
     where F: Frame,
           A: Frame<NumChannels=F::NumChannels>,
-          A::Sample: Amplitude,
-          F::Sample: Duplex<A::Sample>,
+          F::Sample: SelectFloat<A::Sample>,
+          A::Sample: FloatSample,
 {
-    zip_map_in_place(a, b, |af, bf| af.add(bf.zip_map(amp_per_channel, Sample::scale_amplitude)));
+    zip_map_in_place(a, b, |af, bf| af.add_frame(bf.zip_map(amp_per_channel, Sample::scale_amp)));
 }
 
 /// Mutate every element in buffer `a` while reading from each element from buffer `b` in lock-step

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,13 @@ pub use conv::{
     DuplexSlice, DuplexSliceMut,
 };
 pub use frame::Frame;
+pub use signal::Signal;
 pub use types::{I24, U24, I48, U48};
 
 pub mod buffer;
 pub mod conv;
 pub mod frame;
+pub mod signal;
 pub mod types;
 
 /// A trait for working generically across different sample types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! A crate for simplifying generic audio sample processing. Use the **Sample** trait to remain
 //! generic across any audio bit-depth.
 
+#![recursion_limit="512"]
+
 pub use conv::{
     FromSample, ToSample, Duplex,
     FromSampleSlice, ToSampleSlice, DuplexSampleSlice,
@@ -32,14 +34,43 @@ pub trait Sample: Copy
     + std::fmt::Debug
     + PartialOrd
     + PartialEq
-    + std::ops::Add<Output=Self>
-    + std::ops::Sub<Output=Self>
-    + std::ops::Mul<Output=Self>
-    + std::ops::Div<Output=Self>
-    + std::ops::Rem<Output=Self>
 {
+    /// When summing two samples of a signal together, it is necessary for both samples to be
+    /// represented in some signed format. This associated `Addition` type represents the format to
+    /// which `Self` should be converted for optimal `Addition` performance.
+    ///
+    /// For example, u32's optimal `Addition` type would be i32, u8's would be i8, f32's would be
+    /// f32, etc.
+    ///
+    /// Specifying this as an associated type allows us to automatically determine the optimal,
+    /// lossless Addition format type for summing any two unique `Sample` types together.
+    ///
+    /// As a user of the `sample` crate, you will never need to be concerned with this type unless
+    /// you are defining your own unique `Sample` type(s).
+    type Signed: SignedSample + Duplex<Self>;
 
-    /// Convert `self` to any type that implements `FromSample`.
+    /// When multiplying two samples of a signal together, it is necessary for both samples to be
+    /// represented in some signed, floating-point format. This associated `Multiplication` type
+    /// represents the format to which `Self` should be converted for optimal `Multiplication`
+    /// performance.
+    ///
+    /// For example, u32's optimal `Multiplication` type would be f32, u64's would be f64, i8's
+    /// would be f32, etc.
+    ///
+    /// Specifying this as an associated type allows us to automatically determine the optimal,
+    /// lossless Multiplication format type for summing any two unique `Sample` types together.
+    ///
+    /// As a user of the `sample` crate, you will never need to be concerned with this type unless
+    /// you are defining your own unique `Sample` type(s).
+    type Float: FloatSample + Duplex<Self>;
+
+    /// The equilibrium value for the wave that this `Sample` type represents. This is normally the
+    /// value that is equal distance from both the min and max ranges of the sample.
+    ///
+    /// **NOTE:** This will likely be changed to an "associated const" if the feature lands.
+    fn equilibrium() -> Self;
+
+    /// Convert `self` to any type that implements `FromSample<Self>`.
     #[inline]
     fn to_sample<S>(self) -> S
         where Self: ToSample<S>,
@@ -47,7 +78,7 @@ pub trait Sample: Copy
         self.to_sample_()
     }
 
-    /// Create a `Self` from any type that implements `ToSample`.
+    /// Create a `Self` from any type that implements `ToSample<Self>`.
     #[inline]
     fn from_sample<S>(s: S) -> Self
         where Self: FromSample<S>,
@@ -55,11 +86,16 @@ pub trait Sample: Copy
         FromSample::from_sample_(s)
     }
 
-    /// The equilibrium value for the wave that this `Sample` type represents. This is normally the
-    /// value that is equal distance from both the min and max ranges of the sample.
-    ///
-    /// **NOTE:** This will likely be changed to an "associated const" if the feature lands.
-    fn equilibrium() -> Self;
+    /// Sums the sample `other` from some signal onto the carrier signal `self`.
+    #[inline]
+    fn add_sample<S>(self, other: S) -> Self
+        where S: Sample,
+              Self: SelectSigned<S>,
+    {
+        let self_s: <Self as SelectSigned<S>>::Sample = self.to_sample();
+        let other_s: <Self as SelectSigned<S>>::Sample = other.to_sample();
+        (self_s + other_s).to_sample::<Self>()
+    }
 
     /// Multiplies the `Sample` by the given amplitude (either `f32` or `f64`).
     ///
@@ -68,33 +104,27 @@ pub trait Sample: Copy
     /// - A == 1.0 yields the same sample.
     /// - A == 0.0 yields the `Sample::equilibrium`.
     #[inline]
-    fn scale_amplitude<A>(self, amplitude: A) -> Self
-        where Self: Duplex<A>,
-              A: Amplitude,
+    fn scale_amp<F>(self, amp: F) -> Self
+        where F: FloatSample,
+              Self: SelectFloat<F>,
     {
-        (self.to_sample::<A>() * amplitude).to_sample()
+        let self_f: <Self as SelectFloat<F>>::Sample = self.to_sample();
+        let amp_f: <Self as SelectFloat<F>>::Sample = amp.to_sample();
+        (self_f * amp_f).to_sample::<Self>()
     }
 
 }
 
-/// This trait exists in order for us to make `Amplitude` public while restricting it from being
-/// implemented for other types by providing a blanket implementation.
-trait PrivateAmplitude: Sample {}
-impl PrivateAmplitude for f32 {}
-impl PrivateAmplitude for f64 {}
-
-/// Types that may be used as an amplitude multiplier for a signal.
-///
-/// This trait is only implemented for `f32` and `f64` in order to avoid strange behaviour with
-/// user-defined `Amplitude`s.
-pub trait Amplitude: Sample {}
-impl<T> Amplitude for T where T: PrivateAmplitude {}
-
-
 macro_rules! impl_sample {
-    ($($T:ty: $equilibrium:expr),*) => {
+    ($($T:ty:
+       Signed: $Addition:ty,
+       Float: $Modulation:ty,
+       equilibrium: $equilibrium:expr),*) =>
+    {
         $(
             impl Sample for $T {
+                type Signed = $Addition;
+                type Float = $Modulation;
                 fn equilibrium() -> Self {
                     $equilibrium
                 }
@@ -104,18 +134,295 @@ macro_rules! impl_sample {
 }
 
 impl_sample!{
-    i8: 0,
-    i16: 0,
-    I24: types::i24::EQUILIBRIUM,
-    i32: 0,
-    I48: types::i48::EQUILIBRIUM,
-    i64: 0,
-    u8: 128,
-    u16: 32_768,
-    U24: types::u24::EQUILIBRIUM,
-    u32: 2_147_483_648,
-    U48: types::u48::EQUILIBRIUM,
-    u64: 9_223_372_036_854_775_808,
-    f32: 0.0,
-    f64: 0.0
+    i8:  Signed: i8,  Float: f32, equilibrium: 0,
+    i16: Signed: i16, Float: f32, equilibrium: 0,
+    I24: Signed: I24, Float: f32, equilibrium: types::i24::EQUILIBRIUM,
+    i32: Signed: i32, Float: f32, equilibrium: 0,
+    I48: Signed: I48, Float: f64, equilibrium: types::i48::EQUILIBRIUM,
+    i64: Signed: i64, Float: f64, equilibrium: 0,
+    u8:  Signed: i8,  Float: f32, equilibrium: 128,
+    u16: Signed: i16, Float: f32, equilibrium: 32_768,
+    U24: Signed: i32, Float: f32, equilibrium: types::u24::EQUILIBRIUM,
+    u32: Signed: i32, Float: f32, equilibrium: 2_147_483_648,
+    U48: Signed: i64, Float: f64, equilibrium: types::u48::EQUILIBRIUM,
+    u64: Signed: i64, Float: f64, equilibrium: 9_223_372_036_854_775_808,
+    f32: Signed: f32, Float: f32, equilibrium: 0.0,
+    f64: Signed: f64, Float: f64, equilibrium: 0.0
+}
+
+
+/// Sample format types whose equilibrium is at 0.
+///
+/// `Sample`s often need to be converted to some mutual `SignedSample` type for signal addition.
+pub trait SignedSample: Sample + std::ops::Add<Output=Self> {}
+macro_rules! impl_signed_sample { ($($T:ty)*) => { $( impl SignedSample for $T {} )* } }
+impl_signed_sample!(i8 i16 I24 i32 I48 i64 f32 f64);
+
+/// Sample format types represented as floating point numbers.
+///
+/// `Sample`s often need to be converted to some mutual `FloatSample` type for signal scaling and
+/// modulation.
+pub trait FloatSample: Sample + std::ops::Mul<Output=Self> {}
+impl FloatSample for f32 {}
+impl FloatSample for f64 {}
+
+
+/// Allows for selecting the correct `Sample::Signed` between two sample types.
+///
+/// In this case, correct means optimal conversion to and from the type losslessly.
+pub trait SelectSigned<S>: Sample where S: Sample {
+    type Sample: SignedSample + Duplex<Self> + Duplex<S>;
+}
+
+/// Allows for selecting the correct `Sample::Float` for conversions between the two `Sample`s
+/// `Self` and `S`.
+///
+/// In this case, correct means optimal conversion to and from the type losslessly.
+pub trait SelectFloat<S>: Sample where S: Sample {
+    type Sample: FloatSample + Duplex<Self> + Duplex<S>;
+}
+
+
+impl<S> SelectSigned<S> for S where S: Sample {
+    type Sample = S::Signed;
+}
+
+impl<S> SelectFloat<S> for S where S: Sample {
+    type Sample = S::Float;
+}
+
+
+/// Used to simplify implementation of `SelectSigned` and `SelectFloat` for all `Sample` pairs.
+macro_rules! impl_select {
+
+    ($Trait:ident: $A:ty ; $B:ty => $Sample:ty) => {
+        impl $Trait<$B> for $A {
+            type Sample = $Sample;
+        }
+    };
+
+    // This branch implements $Trait<$B> for $A and $Trait<$A> for $B.
+    ($Trait:ident: $A:ty , $B:ty => $Sample:ty, $($rest:tt)*) => {
+        impl_select!($Trait: $A ; $B => $Sample);
+        impl_select!($Trait: $B ; $A => $Sample);
+        impl_select!($Trait: $($rest)*);
+    };
+
+    ($Trait:ident: ) => {};
+}
+
+// For every possible combination of `SignedSample` types, return the `SelectSigned::Sample`
+// between them.
+impl_select! { SelectSigned:
+    u8  , u16 => i16,
+    u8  , U24 => i32,
+    u8  , u32 => i32,
+    u8  , U48 => i64,
+    u8  , u64 => i64,
+    u8  , i8  => i8,
+    u8  , i16 => i16,
+    u8  , I24 => i32,
+    u8  , i32 => i32,
+    u8  , I48 => i64,
+    u8  , i64 => i64,
+    u8  , f32 => f32,
+    u8  , f64 => f64,
+
+    u16 , U24 => i32,
+    u16 , u32 => i32,
+    u16 , U48 => i64,
+    u16 , u64 => i64,
+    u16 , i8  => i16,
+    u16 , i16 => i16,
+    u16 , I24 => i32,
+    u16 , i32 => i32,
+    u16 , I48 => i64,
+    u16 , i64 => i64,
+    u16 , f32 => f32,
+    u16 , f64 => f64,
+
+    U24 , u32 => i32,
+    U24 , U48 => i64,
+    U24 , u64 => i64,
+    U24 , i8  => i32,
+    U24 , i16 => i32,
+    U24 , I24 => i32,
+    U24 , i32 => i32,
+    U24 , I48 => i64,
+    U24 , i64 => i64,
+    U24 , f32 => f32,
+    U24 , f64 => f64,
+
+    u32 , U48 => i64,
+    u32 , u64 => i64,
+    u32 , i8  => i32,
+    u32 , i16 => i32,
+    u32 , I24 => i32,
+    u32 , i32 => i32,
+    u32 , I48 => i64,
+    u32 , i64 => i64,
+    u32 , f32 => f32,
+    u32 , f64 => f64,
+
+    U48 , u64 => i64,
+    U48 , i8  => i64,
+    U48 , i16 => i64,
+    U48 , I24 => i64,
+    U48 , i32 => i64,
+    U48 , I48 => i64,
+    U48 , i64 => i64,
+    U48 , f32 => f64,
+    U48 , f64 => f64,
+
+    u64 , i8  => i64,
+    u64 , i16 => i64,
+    u64 , I24 => i64,
+    u64 , i32 => i64,
+    u64 , I48 => i64,
+    u64 , i64 => i64,
+    u64 , f32 => f64,
+    u64 , f64 => f64,
+
+    i8  , i16 => i16,
+    i8  , I24 => i32,
+    i8  , i32 => i32,
+    i8  , I48 => i64,
+    i8  , i64 => i64,
+    i8  , f32 => f32,
+    i8  , f64 => f64,
+
+    i16 , I24 => i32,
+    i16 , i32 => i32,
+    i16 , I48 => i64,
+    i16 , i64 => i64,
+    i16 , f32 => f32,
+    i16 , f64 => f64,
+
+    I24 , i32 => i32,
+    I24 , I48 => i64,
+    I24 , i64 => i64,
+    I24 , f32 => f32,
+    I24 , f64 => f64,
+
+    i32 , I48 => i64,
+    i32 , i64 => i64,
+    i32 , f32 => f32,
+    i32 , f64 => f64,
+
+    I48 , i64 => i64,
+    I48 , f32 => f64,
+    I48 , f64 => f64,
+
+    i64 , f32 => f64,
+    i64 , f64 => f64,
+
+    f32 , f64 => f64,
+}
+
+// For every possible combination of `FloatSample` types, return the `SelectFloat::Sample` between
+// them.
+impl_select! { SelectFloat:
+    u8  , u16 => f32,
+    u8  , U24 => f32,
+    u8  , u32 => f32,
+    u8  , U48 => f64,
+    u8  , u64 => f64,
+    u8  , i8  => f32,
+    u8  , i16 => f32,
+    u8  , I24 => f32,
+    u8  , i32 => f32,
+    u8  , I48 => f64,
+    u8  , i64 => f64,
+    u8  , f32 => f32,
+    u8  , f64 => f64,
+
+    u16 , U24 => f32,
+    u16 , u32 => f32,
+    u16 , U48 => f64,
+    u16 , u64 => f64,
+    u16 , i8  => f32,
+    u16 , i16 => f32,
+    u16 , I24 => f32,
+    u16 , i32 => f32,
+    u16 , I48 => f64,
+    u16 , i64 => f64,
+    u16 , f32 => f32,
+    u16 , f64 => f64,
+
+    U24 , u32 => f32,
+    U24 , U48 => f64,
+    U24 , u64 => f64,
+    U24 , i8  => f32,
+    U24 , i16 => f32,
+    U24 , I24 => f32,
+    U24 , i32 => f32,
+    U24 , I48 => f64,
+    U24 , i64 => f64,
+    U24 , f32 => f32,
+    U24 , f64 => f64,
+
+    u32 , U48 => f64,
+    u32 , u64 => f64,
+    u32 , i8  => f32,
+    u32 , i16 => f32,
+    u32 , I24 => f32,
+    u32 , i32 => f32,
+    u32 , I48 => f64,
+    u32 , i64 => f64,
+    u32 , f32 => f32,
+    u32 , f64 => f64,
+
+    U48 , u64 => f64,
+    U48 , i8  => f64,
+    U48 , i16 => f64,
+    U48 , I24 => f64,
+    U48 , i32 => f64,
+    U48 , I48 => f64,
+    U48 , i64 => f64,
+    U48 , f32 => f64,
+    U48 , f64 => f64,
+
+    u64 , i8  => f64,
+    u64 , i16 => f64,
+    u64 , I24 => f64,
+    u64 , i32 => f64,
+    u64 , I48 => f64,
+    u64 , i64 => f64,
+    u64 , f32 => f64,
+    u64 , f64 => f64,
+
+    i8  , i16 => f32,
+    i8  , I24 => f32,
+    i8  , i32 => f32,
+    i8  , I48 => f64,
+    i8  , i64 => f64,
+    i8  , f32 => f32,
+    i8  , f64 => f64,
+
+    i16 , I24 => f32,
+    i16 , i32 => f32,
+    i16 , I48 => f64,
+    i16 , i64 => f64,
+    i16 , f32 => f32,
+    i16 , f64 => f64,
+
+    I24 , i32 => f32,
+    I24 , I48 => f64,
+    I24 , i64 => f64,
+    I24 , f32 => f32,
+    I24 , f64 => f64,
+
+    i32 , I48 => f64,
+    i32 , i64 => f64,
+    i32 , f32 => f32,
+    i32 , f64 => f64,
+
+    I48 , i64 => f64,
+    I48 , f32 => f64,
+    I48 , f64 => f64,
+
+    i64 , f32 => f64,
+    i64 , f64 => f64,
+
+    f32 , f64 => f64,
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -7,7 +7,13 @@ impl<I> Signal for I
     where I: Iterator,
           I::Item: Frame, {}
 
-/// An extension over `Iterator`s that yield `Frame`s.
+/// A trait that allows us to treat `Iterator`s that yield `Frame`s as a multi-channel PCM signal.
+///
+/// For example, `Signal` allows us to add two signals, modulate a signal's amplitude by another
+/// signal, scale a signals amplitude and much more.
+///
+/// `Signal` has a blanked implementation for all `Iterator`s whose `Item` associated types
+/// implement `Frame`.
 pub trait Signal: Iterator + Sized
     where <Self as Iterator>::Item: Frame,
 {
@@ -29,8 +35,8 @@ pub trait Signal: Iterator + Sized
     /// Produces an `Iterator` that modulates the amplitude of `self` with `other` where `other` is
     /// some `Signal` yielding `Frame`s with `Sample`s that implement `Amplitude` (f32 or f64).
     ///
-    /// The `Iterator` steps them forward in lockstep, multiplies the amplitude of each pair of
-    /// `Frame`s together and yields the resulting `Frame`s.
+    /// The `Iterator` steps both signals forward in lockstep, multiplies the amplitude of each
+    /// pair of `Frame`s together and yields the resulting `Frame`s.
     ///
     /// The `Iterator` will return `None` when either of the `Signal`s first yields `None`.
     #[inline]

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,4 +1,4 @@
-use {FloatSample, Frame, Sample, SelectFloat};
+use {Frame, Sample};
 use std;
 
 
@@ -16,42 +16,8 @@ pub trait Signal: Iterator + Sized
     where Self::Item: Frame,
 {
 
-    /// Produces an `Iterator` that takes two `Signal`s, steps them forward in lockstep, sums each
-    /// pair of `Frame`s together and yields the resulting `Frame`s.
-    ///
-    /// The `Iterator` will return `None` when either of the `Signal`s first yields `None`.
-    #[inline]
-    fn zip_add<S>(self, other: S) -> ZipAdd<Self, S>
-        where S: Signal<Item=Self::Item>,
-    {
-        ZipAdd {
-            signal_a: self,
-            signal_b: other,
-        }
-    }
-
-    /// Produces an `Iterator` that modulates the amplitude of `self` with `other` where `other` is
-    /// some `Signal` yielding `Frame`s with `Sample`s that implement `Amplitude` (f32 or f64).
-    ///
-    /// The `Iterator` steps both signals forward in lockstep, multiplies the amplitude of each
-    /// pair of `Frame`s together and yields the resulting `Frame`s.
-    ///
-    /// The `Iterator` will return `None` when either of the `Signal`s first yields `None`.
-    #[inline]
-    fn zip_mod_amp<S>(self, other: S) -> ZipModAmp<Self, S>
-        where S: Signal,
-              S::Item: Frame<NumChannels=<Self::Item as Frame>::NumChannels>,
-              <Self::Item as Frame>::Sample: SelectFloat<<S::Item as Frame>::Sample>,
-              <S::Item as Frame>::Sample: FloatSample,
-    {
-        ZipModAmp {
-            signal_a: self,
-            signal_b: other,
-        }
-    }
-
-    /// Produces an `Iterator` that scales the amplitude of every `Frame` in `self` by the given
-    /// `Amplitude` scalar.
+    /// Provides an iterator that yields the sum of the frames yielded by both `other` and `self`
+    /// in lock-step.
     ///
     /// # Example
     ///
@@ -61,20 +27,54 @@ pub trait Signal: Iterator + Sized
     /// use sample::Signal;
     ///
     /// fn main() {
-    ///     let frames = [[0.2], [-0.5], [-0.4], [0.3]];
-    ///     let signal = frames.iter().cloned();
-    ///     let scaled: Vec<[f32; 1]> = signal.scale_amp(2.0).collect();
-    ///     assert_eq!(scaled, vec![[0.4], [-1.0], [-0.8], [0.6]]);
+    ///     let a = [[0.2], [-0.6], [0.5]];
+    ///     let b = [[0.2], [0.1], [-0.8]];
+    ///     let a_signal = a.iter().cloned();
+    ///     let b_signal = b.iter().cloned();
+    ///     let added: Vec<[f32; 1]> = a_signal.add_amp(b_signal).collect();
+    ///     assert_eq!(added, vec![[0.4], [-0.5], [-0.3]]);
     /// }
     /// ```
     #[inline]
-    fn scale_amp<A>(self, amp: A) -> ScaleAmp<Self, A>
-        where A: FloatSample,
-              <Self::Item as Frame>::Sample: SelectFloat<A>,
+    fn add_amp<S>(self, other: S) -> AddAmp<Self, S>
+        where S: Signal,
+              S::Item: Frame<Sample=<<Self::Item as Frame>::Sample as Sample>::Signed,
+                             NumChannels=<Self::Item as Frame>::NumChannels>,
     {
-        ScaleAmp {
-            signal: self,
-            amp: amp,
+        AddAmp {
+            a: self,
+            b: other,
+        }
+    }
+
+    /// Provides an iterator that yields the product of the frames yielded by both `other` and
+    /// `self` in lock-step.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Signal;
+    ///
+    /// fn main() {
+    ///     let a = [[0.25], [-0.8], [-0.5]];
+    ///     let b = [[0.2], [0.5], [0.8]];
+    ///     let a_signal = a.iter().cloned();
+    ///     let b_signal = b.iter().cloned();
+    ///     let added: Vec<[f32; 1]> = a_signal.mul_amp(b_signal).collect();
+    ///     assert_eq!(added, vec![[0.05], [-0.4], [-0.4]]);
+    /// }
+    /// ```
+    #[inline]
+    fn mul_amp<S>(self, other: S) -> MulAmp<Self, S>
+        where S: Signal,
+              S::Item: Frame<Sample=<<Self::Item as Frame>::Sample as Sample>::Float,
+                             NumChannels=<Self::Item as Frame>::NumChannels>,
+    {
+        MulAmp {
+            a: self,
+            b: other,
         }
     }
 
@@ -96,10 +96,93 @@ pub trait Signal: Iterator + Sized
     /// }
     /// ```
     #[inline]
-    fn offset_amp(self, offset: <Self::Item as Frame>::Sample) -> OffsetAmp<Self> {
+    fn offset_amp(self, offset: <<Self::Item as Frame>::Sample as Sample>::Signed)
+        -> OffsetAmp<Self>
+    {
         OffsetAmp {
             signal: self,
             offset: offset,
+        }
+    }
+
+    /// Produces an `Iterator` that scales the amplitude of the sample of each channel in every
+    /// `Frame` yielded by `self` by the given amplitude.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Signal;
+    ///
+    /// fn main() {
+    ///     let frames = [[0.2], [-0.5], [-0.4], [0.3]];
+    ///     let signal = frames.iter().cloned();
+    ///     let scaled: Vec<[f32; 1]> = signal.scale_amp(2.0).collect();
+    ///     assert_eq!(scaled, vec![[0.4], [-1.0], [-0.8], [0.6]]);
+    /// }
+    /// ```
+    #[inline]
+    fn scale_amp(self, amp: <<Self::Item as Frame>::Sample as Sample>::Float) -> ScaleAmp<Self> {
+        ScaleAmp {
+            signal: self,
+            amp: amp,
+        }
+    }
+
+    /// Produces an `Iterator` that offsets the amplitude of every `Frame` in `self` by the
+    /// respective amplitudes in each channel of the given `amp_frame`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Signal;
+    ///
+    /// fn main() {
+    ///     let frames = [[0.5, 0.3], [-0.25, 0.9]];
+    ///     let mut signal = frames.iter().cloned().offset_amp_per_channel([0.25, -0.5]);
+    ///     assert_eq!(signal.next().unwrap(), [0.75, -0.2]);
+    ///     assert_eq!(signal.next().unwrap(), [0.0, 0.4]);
+    /// }
+    /// ```
+    #[inline]
+    fn offset_amp_per_channel<F>(self, amp_frame: F) -> OffsetAmpPerChannel<Self, F>
+        where F: Frame<Sample=<<Self::Item as Frame>::Sample as Sample>::Signed,
+                       NumChannels=<Self::Item as Frame>::NumChannels>,
+    {
+        OffsetAmpPerChannel {
+            signal: self,
+            amp_frame: amp_frame,
+        }
+    }
+
+    /// Produces an `Iterator` that scales the amplitude of every `Frame` in `self` by the
+    /// respective amplitudes in each channel of the given `amp_frame`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Signal;
+    ///
+    /// fn main() {
+    ///     let frames = [[0.2, -0.5], [-0.4, 0.3]];
+    ///     let mut signal = frames.iter().cloned().scale_amp_per_channel([0.5, 2.0]);
+    ///     assert_eq!(signal.next().unwrap(), [0.1, -1.0]);
+    ///     assert_eq!(signal.next().unwrap(), [-0.2, 0.6]);
+    /// }
+    /// ```
+    #[inline]
+    fn scale_amp_per_channel<F>(self, amp_frame: F) -> ScaleAmpPerChannel<Self, F>
+        where F: Frame<Sample=<<Self::Item as Frame>::Sample as Sample>::Float,
+                       NumChannels=<Self::Item as Frame>::NumChannels>,
+    {
+        ScaleAmpPerChannel {
+            signal: self,
+            amp_frame: amp_frame,
         }
     }
 
@@ -110,6 +193,59 @@ pub trait Signal: Iterator + Sized
 #[derive(Clone)]
 pub struct Equilibrium<F> {
     frame_type: std::marker::PhantomData<F>,
+}
+
+/// An iterator that yields the sum of the frames yielded by both `other` and `self` in lock-step.
+#[derive(Clone)]
+pub struct AddAmp<A, B> {
+    a: A,
+    b: B,
+}
+
+/// An iterator that yields the product of the frames yielded by both `other` and `self` in
+/// lock-step.
+#[derive(Clone)]
+pub struct MulAmp<A, B> {
+    a: A,
+    b: B,
+}
+
+/// Provides an iterator that offsets the amplitude of every channel in each frame of the
+/// signal by some sample value and yields the resulting frames.
+#[derive(Clone)]
+pub struct OffsetAmp<S>
+    where S: Signal,
+          S::Item: Frame,
+{
+    signal: S,
+    offset: <<S::Item as Frame>::Sample as Sample>::Signed,
+}
+
+/// An `Iterator` that scales the amplitude of the sample of each channel in every `Frame` yielded
+/// by `self` by the given amplitude.
+#[derive(Clone)]
+pub struct ScaleAmp<S>
+    where S: Signal,
+          S::Item: Frame,
+{
+    signal: S,
+    amp: <<S::Item as Frame>::Sample as Sample>::Float,
+}
+
+/// An `Iterator` that scales the amplitude of every `Frame` in `self` by the respective amplitudes
+/// in each channel of the given `amp` `Frame`.
+#[derive(Clone)]
+pub struct OffsetAmpPerChannel<S, F> {
+    signal: S,
+    amp_frame: F,
+}
+
+/// An `Iterator` that scales the amplitude of every `Frame` in `self` by the respective amplitudes
+/// in each channel of the given `amp` `Frame`.
+#[derive(Clone)]
+pub struct ScaleAmpPerChannel<S, F> {
+    signal: S,
+    amp_frame: F,
 }
 
 /// An iterator that takes two `Signal`s, steps them forward in lockstep, sums each pair of
@@ -130,25 +266,6 @@ pub struct ZipAdd<A, B> {
 pub struct ZipModAmp<A, B> {
     signal_a: A,
     signal_b: B,
-}
-
-/// Produces an `Iterator` that scales the amplitude of every `Frame` in `self` by the given
-/// `Amplitude` scalar.
-#[derive(Clone)]
-pub struct ScaleAmp<S, A> {
-    signal: S,
-    amp: A,
-}
-
-/// Provides an iterator that offsets the amplitude of every channel in each frame of the
-/// signal by some sample value and yields the resulting frames.
-#[derive(Clone)]
-pub struct OffsetAmp<S>
-    where S: Signal,
-          S::Item: Frame,
-{
-    signal: S,
-    offset: <S::Item as Frame>::Sample,
 }
 
 
@@ -184,45 +301,55 @@ impl<F> Iterator for Equilibrium<F>
     }
 }
 
-impl<A, B> Iterator for ZipAdd<A, B>
-    where A: Signal,
-          B: Signal<Item=A::Item>,
-          A::Item: Frame,
-{
-    type Item = A::Item;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        self.signal_a.next().and_then(|f_a| self.signal_b.next().map(|f_b| f_a.add_frame(f_b)))
-    }
-}
-
-impl<A, B> Iterator for ZipModAmp<A, B>
+impl<A, B> Iterator for AddAmp<A, B>
     where A: Signal,
           B: Signal,
           A::Item: Frame,
-          B::Item: Frame<NumChannels=<A::Item as Frame>::NumChannels>,
-          <A::Item as Frame>::Sample: SelectFloat<<B::Item as Frame>::Sample>,
-          <B::Item as Frame>::Sample: FloatSample,
+          B::Item: Frame<Sample=<<A::Item as Frame>::Sample as Sample>::Signed,
+                         NumChannels=<A::Item as Frame>::NumChannels>,
 {
     type Item = A::Item;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.signal_a.next().and_then(|f_a| self.signal_b.next().map(|f_b| {
-            f_a.zip_map(f_b, |s_a, s_b| s_a.scale_amp(s_b))
-        }))
+        self.a.next().and_then(|a_f| self.b.next().map(|b_f| a_f.add_amp(b_f)))
     }
 }
 
-impl<S, A> Iterator for ScaleAmp<S, A>
+impl<A, B> Iterator for MulAmp<A, B>
+    where A: Signal,
+          B: Signal,
+          A::Item: Frame,
+          B::Item: Frame<Sample=<<A::Item as Frame>::Sample as Sample>::Float,
+                         NumChannels=<A::Item as Frame>::NumChannels>,
+{
+    type Item = A::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.a.next().and_then(|a_f| self.b.next().map(|b_f| a_f.mul_amp(b_f)))
+    }
+}
+
+impl<S> Iterator for ScaleAmp<S>
     where S: Signal,
           S::Item: Frame,
-          A: FloatSample,
-          <S::Item as Frame>::Sample: SelectFloat<A>,
 {
     type Item = S::Item;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.signal.next().map(|f| f.scale_amp(self.amp))
+    }
+}
+
+impl<S, F> Iterator for ScaleAmpPerChannel<S, F>
+    where S: Signal,
+          S::Item: Frame,
+          F: Frame<Sample=<<S::Item as Frame>::Sample as Sample>::Float,
+                   NumChannels=<S::Item as Frame>::NumChannels>,
+{
+    type Item = S::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.signal.next().map(|f| f.mul_amp(self.amp_frame))
     }
 }
 
@@ -234,5 +361,18 @@ impl<S> Iterator for OffsetAmp<S>
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.signal.next().map(|f| f.offset_amp(self.offset))
+    }
+}
+
+impl<S, F> Iterator for OffsetAmpPerChannel<S, F>
+    where S: Signal,
+          S::Item: Frame,
+          F: Frame<Sample=<<S::Item as Frame>::Sample as Sample>::Signed,
+                   NumChannels=<S::Item as Frame>::NumChannels>,
+{
+    type Item = S::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.signal.next().map(|f| f.add_amp(self.amp_frame))
     }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,0 +1,172 @@
+use {Amplitude, Duplex, Frame, Sample};
+use std;
+
+
+// Implement `Signal` for all `Iterator`s that yield `Frame`s.
+impl<I> Signal for I
+    where I: Iterator,
+          I::Item: Frame, {}
+
+/// An extension over `Iterator`s that yield `Frame`s.
+pub trait Signal: Iterator + Sized
+    where <Self as Iterator>::Item: Frame,
+{
+
+    /// Produces an `Iterator` that takes two `Signal`s, steps them forward in lockstep, sums each
+    /// pair of `Frame`s together and yields the resulting `Frame`s.
+    ///
+    /// The `Iterator` will return `None` when either of the `Signal`s first yields `None`.
+    #[inline]
+    fn zip_add<S>(self, other: S) -> ZipAdd<Self, S>
+        where S: Signal<Item=Self::Item>,
+    {
+        ZipAdd {
+            signal_a: self,
+            signal_b: other,
+        }
+    }
+
+    /// Produces an `Iterator` that modulates the amplitude of `self` with `other` where `other` is
+    /// some `Signal` yielding `Frame`s with `Sample`s that implement `Amplitude` (f32 or f64).
+    ///
+    /// The `Iterator` steps them forward in lockstep, multiplies the amplitude of each pair of
+    /// `Frame`s together and yields the resulting `Frame`s.
+    ///
+    /// The `Iterator` will return `None` when either of the `Signal`s first yields `None`.
+    #[inline]
+    fn zip_mod_amp<S>(self, other: S) -> ZipModAmp<Self, S>
+        where S: Signal,
+              S::Item: Frame<NumChannels=<Self::Item as Frame>::NumChannels>,
+              <Self::Item as Frame>::Sample: Duplex<<S::Item as Frame>::Sample>,
+              <S::Item as Frame>::Sample: Amplitude,
+    {
+        ZipModAmp {
+            signal_a: self,
+            signal_b: other,
+        }
+    }
+
+    /// Produces an `Iterator` that scales the amplitude of every `Frame` in `self` by the given
+    /// `Amplitude` scalar.
+    #[inline]
+    fn scale_amp<A>(self, amp: A) -> ScaleAmp<Self, A>
+        where <Self::Item as Frame>::Sample: Duplex<A>,
+              A: Amplitude,
+    {
+        ScaleAmp {
+            signal: self,
+            amp: amp,
+        }
+    }
+
+}
+
+
+/// An iterator that endlessly yields `Frame`s of type `F` at equilibrium.
+#[derive(Clone)]
+pub struct Equilibrium<F> {
+    frame_type: std::marker::PhantomData<F>,
+}
+
+/// An iterator that takes two `Signal`s, steps them forward in lockstep, sums each pair of
+/// `Frame`s together and yields the resulting `Frame`s.
+#[derive(Clone)]
+pub struct ZipAdd<A, B> {
+    signal_a: A,
+    signal_b: B,
+}
+
+/// An `Iterator` that modulates the amplitude of `self` with `other`.
+///
+/// The `Iterator` steps them forward in lockstep, multiplies the amplitude of each pair of
+/// `Frame`s together and yields the resulting `Frame`s.
+///
+/// The `Iterator` will return `None` when either of the `Signal`s first yields `None`.
+#[derive(Clone)]
+pub struct ZipModAmp<A, B> {
+    signal_a: A,
+    signal_b: B,
+}
+
+/// Produces an `Iterator` that scales the amplitude of every `Frame` in `self` by the given
+/// `Amplitude` scalar.
+#[derive(Clone)]
+pub struct ScaleAmp<S, A> {
+    signal: S,
+    amp: A,
+}
+
+
+/// Provides an iterator that endlessly yields `Frame`s of type `F` at equilibrium.
+///
+/// # Example
+///
+/// ```rust
+/// extern crate sample;
+///
+/// use sample::Signal;
+///
+/// fn main() {
+///     let equilibrium: Vec<[f32; 1]> = sample::signal::equilibrium().take(4).collect();
+///     assert_eq!(equilibrium, vec![[0.0], [0.0], [0.0], [0.0]]);
+///
+///     let equilibrium: Vec<[u8; 2]> = sample::signal::equilibrium().take(3).collect();
+///     assert_eq!(equilibrium, vec![[128, 128], [128, 128], [128, 128]]);
+/// }
+/// ```
+pub fn equilibrium<F>() -> Equilibrium<F> {
+    Equilibrium { frame_type: std::marker::PhantomData }
+}
+
+
+impl<F> Iterator for Equilibrium<F>
+    where F: Frame,
+{
+    type Item = F;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        Some(F::equilibrium())
+    }
+}
+
+impl<A, B> Iterator for ZipAdd<A, B>
+    where A: Signal,
+          B: Signal<Item=A::Item>,
+          A::Item: Frame,
+{
+    type Item = A::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.signal_a.next().and_then(|f_a| self.signal_b.next().map(|f_b| f_a.add(f_b)))
+    }
+}
+
+impl<A, B> Iterator for ZipModAmp<A, B>
+    where A: Signal,
+          B: Signal,
+          A::Item: Frame,
+          B::Item: Frame<NumChannels=<A::Item as Frame>::NumChannels>,
+          <A::Item as Frame>::Sample: Duplex<<B::Item as Frame>::Sample>,
+          <B::Item as Frame>::Sample: Amplitude,
+{
+    type Item = A::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.signal_a.next().and_then(|f_a| self.signal_b.next().map(|f_b| {
+            f_a.zip_map(f_b, |s_a, s_b| s_a.scale_amplitude(s_b))
+        }))
+    }
+}
+
+impl<S, A> Iterator for ScaleAmp<S, A>
+    where S: Signal,
+          S::Item: Frame,
+          <S::Item as Frame>::Sample: Duplex<A>,
+          A: Amplitude,
+{
+    type Item = S::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.signal.next().map(|f| f.scale_amplitude(self.amp))
+    }
+}

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,11 +1,9 @@
-use {Amplitude, Duplex, Frame, Sample};
+use {FloatSample, Frame, Sample, SelectFloat};
 use std;
 
 
-// Implement `Signal` for all `Iterator`s that yield `Frame`s.
-impl<I> Signal for I
-    where I: Iterator,
-          I::Item: Frame, {}
+/// Implement `Signal` for all `Iterator`s that yield `Frame`s.
+impl<I> Signal for I where I: Iterator, I::Item: Frame {}
 
 /// A trait that allows us to treat `Iterator`s that yield `Frame`s as a multi-channel PCM signal.
 ///
@@ -15,7 +13,7 @@ impl<I> Signal for I
 /// `Signal` has a blanked implementation for all `Iterator`s whose `Item` associated types
 /// implement `Frame`.
 pub trait Signal: Iterator + Sized
-    where <Self as Iterator>::Item: Frame,
+    where Self::Item: Frame,
 {
 
     /// Produces an `Iterator` that takes two `Signal`s, steps them forward in lockstep, sums each
@@ -43,8 +41,8 @@ pub trait Signal: Iterator + Sized
     fn zip_mod_amp<S>(self, other: S) -> ZipModAmp<Self, S>
         where S: Signal,
               S::Item: Frame<NumChannels=<Self::Item as Frame>::NumChannels>,
-              <Self::Item as Frame>::Sample: Duplex<<S::Item as Frame>::Sample>,
-              <S::Item as Frame>::Sample: Amplitude,
+              <Self::Item as Frame>::Sample: SelectFloat<<S::Item as Frame>::Sample>,
+              <S::Item as Frame>::Sample: FloatSample,
     {
         ZipModAmp {
             signal_a: self,
@@ -54,14 +52,54 @@ pub trait Signal: Iterator + Sized
 
     /// Produces an `Iterator` that scales the amplitude of every `Frame` in `self` by the given
     /// `Amplitude` scalar.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Signal;
+    ///
+    /// fn main() {
+    ///     let frames = [[0.2], [-0.5], [-0.4], [0.3]];
+    ///     let signal = frames.iter().cloned();
+    ///     let scaled: Vec<[f32; 1]> = signal.scale_amp(2.0).collect();
+    ///     assert_eq!(scaled, vec![[0.4], [-1.0], [-0.8], [0.6]]);
+    /// }
+    /// ```
     #[inline]
     fn scale_amp<A>(self, amp: A) -> ScaleAmp<Self, A>
-        where <Self::Item as Frame>::Sample: Duplex<A>,
-              A: Amplitude,
+        where A: FloatSample,
+              <Self::Item as Frame>::Sample: SelectFloat<A>,
     {
         ScaleAmp {
             signal: self,
             amp: amp,
+        }
+    }
+
+    /// Provides an iterator that offsets the amplitude of every channel in each frame of the
+    /// signal by some sample value and yields the resulting frames.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Signal;
+    ///
+    /// fn main() {
+    ///     let frames = [[0.25, 0.4], [-0.2, -0.5]];
+    ///     let signal = frames.iter().cloned();
+    ///     let offset: Vec<[f32; 2]> = signal.offset_amp(0.5).collect();
+    ///     assert_eq!(offset, vec![[0.75, 0.9], [0.3, 0.0]]);
+    /// }
+    /// ```
+    #[inline]
+    fn offset_amp(self, offset: <Self::Item as Frame>::Sample) -> OffsetAmp<Self> {
+        OffsetAmp {
+            signal: self,
+            offset: offset,
         }
     }
 
@@ -100,6 +138,17 @@ pub struct ZipModAmp<A, B> {
 pub struct ScaleAmp<S, A> {
     signal: S,
     amp: A,
+}
+
+/// Provides an iterator that offsets the amplitude of every channel in each frame of the
+/// signal by some sample value and yields the resulting frames.
+#[derive(Clone)]
+pub struct OffsetAmp<S>
+    where S: Signal,
+          S::Item: Frame,
+{
+    signal: S,
+    offset: <S::Item as Frame>::Sample,
 }
 
 
@@ -143,7 +192,7 @@ impl<A, B> Iterator for ZipAdd<A, B>
     type Item = A::Item;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.signal_a.next().and_then(|f_a| self.signal_b.next().map(|f_b| f_a.add(f_b)))
+        self.signal_a.next().and_then(|f_a| self.signal_b.next().map(|f_b| f_a.add_frame(f_b)))
     }
 }
 
@@ -152,14 +201,14 @@ impl<A, B> Iterator for ZipModAmp<A, B>
           B: Signal,
           A::Item: Frame,
           B::Item: Frame<NumChannels=<A::Item as Frame>::NumChannels>,
-          <A::Item as Frame>::Sample: Duplex<<B::Item as Frame>::Sample>,
-          <B::Item as Frame>::Sample: Amplitude,
+          <A::Item as Frame>::Sample: SelectFloat<<B::Item as Frame>::Sample>,
+          <B::Item as Frame>::Sample: FloatSample,
 {
     type Item = A::Item;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.signal_a.next().and_then(|f_a| self.signal_b.next().map(|f_b| {
-            f_a.zip_map(f_b, |s_a, s_b| s_a.scale_amplitude(s_b))
+            f_a.zip_map(f_b, |s_a, s_b| s_a.scale_amp(s_b))
         }))
     }
 }
@@ -167,12 +216,23 @@ impl<A, B> Iterator for ZipModAmp<A, B>
 impl<S, A> Iterator for ScaleAmp<S, A>
     where S: Signal,
           S::Item: Frame,
-          <S::Item as Frame>::Sample: Duplex<A>,
-          A: Amplitude,
+          A: FloatSample,
+          <S::Item as Frame>::Sample: SelectFloat<A>,
 {
     type Item = S::Item;
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.signal.next().map(|f| f.scale_amplitude(self.amp))
+        self.signal.next().map(|f| f.scale_amp(self.amp))
+    }
+}
+
+impl<S> Iterator for OffsetAmp<S>
+    where S: Signal,
+          S::Item: Frame,
+{
+    type Item = S::Item;
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.signal.next().map(|f| f.offset_amp(self.offset))
     }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,7 +1,7 @@
 //! This module provides various helper functions for performing operations on slices of frames.
 
 use {
-    Frame, Sample, FloatSample, SelectFloat,
+    Frame, Sample,
     ToSampleSlice, ToSampleSliceMut, ToFrameSlice, ToFrameSliceMut,
     FromSampleSlice, FromSampleSliceMut, FromFrameSlice, FromFrameSliceMut,
 };
@@ -26,11 +26,11 @@ use {
 ///
 /// fn main() {
 ///     let foo = &[0.0, 0.5, 0.0, -0.5][..];
-///     let bar = sample::buffer::to_frame_slice(foo);
+///     let bar = sample::slice::to_frame_slice(foo);
 ///     assert_eq!(bar, Some(&[[0.0, 0.5], [0.0, -0.5]][..]));
 ///
 ///     let foo = &[0.0, 0.5, 0.0][..];
-///     let bar = sample::buffer::to_frame_slice(foo);
+///     let bar = sample::slice::to_frame_slice(foo);
 ///     assert_eq!(bar, None::<&[[f32; 2]]>);
 /// }
 /// ```
@@ -55,11 +55,11 @@ pub fn to_frame_slice<'a, T, F>(slice: T) -> Option<&'a [F]>
 ///
 /// fn main() {
 ///     let foo = &mut [0.0, 0.5, 0.0, -0.5][..];
-///     let bar = sample::buffer::to_frame_slice_mut(foo);
+///     let bar = sample::slice::to_frame_slice_mut(foo);
 ///     assert_eq!(bar, Some(&mut [[0.0, 0.5], [0.0, -0.5]][..]));
 ///
 ///     let foo = &mut [0.0, 0.5, 0.0][..];
-///     let bar = sample::buffer::to_frame_slice_mut(foo);
+///     let bar = sample::slice::to_frame_slice_mut(foo);
 ///     assert_eq!(bar, None::<&mut [[f32; 2]]>);
 /// }
 /// ```
@@ -81,7 +81,7 @@ pub fn to_frame_slice_mut<'a, T, F>(slice: T) -> Option<&'a mut [F]>
 ///
 /// fn main() {
 ///     let foo = &[[0.0, 0.5], [0.0, -0.5]][..];
-///     let bar = sample::buffer::to_sample_slice(foo);
+///     let bar = sample::slice::to_sample_slice(foo);
 ///     assert_eq!(bar, &[0.0, 0.5, 0.0, -0.5][..]);
 /// }
 /// ```
@@ -103,7 +103,7 @@ pub fn to_sample_slice<'a, T, S>(slice: T) -> &'a [S]
 ///
 /// fn main() {
 ///     let foo = &mut [[0.0, 0.5], [0.0, -0.5]][..];
-///     let bar = sample::buffer::to_sample_slice_mut(foo);
+///     let bar = sample::slice::to_sample_slice_mut(foo);
 ///     assert_eq!(bar, &mut [0.0, 0.5, 0.0, -0.5][..]);
 /// }
 /// ```
@@ -128,7 +128,7 @@ pub fn to_sample_slice_mut<'a, T, S>(slice: T) -> &'a mut [S]
 ///
 /// fn main() {
 ///     let foo = &[0.0, 0.5, 0.0, -0.5][..];
-///     let bar: Option<&_> = sample::buffer::from_sample_slice(foo);
+///     let bar: Option<&_> = sample::slice::from_sample_slice(foo);
 ///     assert_eq!(bar, Some(&[[0.0, 0.5], [0.0, -0.5]][..]));
 /// }
 /// ```
@@ -153,7 +153,7 @@ pub fn from_sample_slice<'a, T, S>(slice: &'a [S]) -> Option<T>
 ///
 /// fn main() {
 ///     let foo = &mut [0.0, 0.5, 0.0, -0.5][..];
-///     let bar: Option<&mut _> = sample::buffer::from_sample_slice_mut(foo);
+///     let bar: Option<&mut _> = sample::slice::from_sample_slice_mut(foo);
 ///     assert_eq!(bar, Some(&mut [[0.0, 0.5], [0.0, -0.5]][..]));
 /// }
 /// ```
@@ -175,7 +175,7 @@ pub fn from_sample_slice_mut<'a, T, S>(slice: &'a mut [S]) -> Option<T>
 ///
 /// fn main() {
 ///     let foo = &[[0.0, 0.5], [0.0, -0.5]][..];
-///     let bar: &[f32] = sample::buffer::from_frame_slice(foo);
+///     let bar: &[f32] = sample::slice::from_frame_slice(foo);
 ///     assert_eq!(bar, &[0.0, 0.5, 0.0, -0.5][..]);
 /// }
 /// ```
@@ -197,7 +197,7 @@ pub fn from_frame_slice<'a, T, F>(slice: &'a [F]) -> T
 ///
 /// fn main() {
 ///     let foo = &mut [[0.0, 0.5], [0.0, -0.5]][..];
-///     let bar: &mut [f32] = sample::buffer::from_frame_slice_mut(foo);
+///     let bar: &mut [f32] = sample::slice::from_frame_slice_mut(foo);
 ///     assert_eq!(bar, &mut [0.0, 0.5, 0.0, -0.5][..]);
 /// }
 /// ```
@@ -212,7 +212,7 @@ pub fn from_frame_slice_mut<'a, T, F>(slice: &'a mut [F]) -> T
 ///// Utility Functions
 
 
-/// Mutate every element in the buffer with the given function.
+/// Mutate every element in the slice with the given function.
 #[inline]
 pub fn map_in_place<F, M>(a: &mut [F], mut map: M)
     where M: FnMut(F) -> F,
@@ -223,7 +223,7 @@ pub fn map_in_place<F, M>(a: &mut [F], mut map: M)
     }
 }
 
-/// Sets the buffer of samples at the `Sample`'s equilibrium value.
+/// Sets the slice of frames at the associated `Sample`'s equilibrium value.
 #[inline]
 pub fn equilibrium<F>(a: &mut [F])
     where F: Frame,
@@ -231,8 +231,8 @@ pub fn equilibrium<F>(a: &mut [F])
     map_in_place(a, |_| F::equilibrium())
 }
 
-/// Mutate every element in buffer `a` while reading from each element from buffer `b` in lock-step
-/// using the given function.
+/// Mutate every frame in slice `a` while reading from each frame in slice `b` in lock-step using
+/// the given function.
 ///
 /// **Panics** if the length of `b` is not equal to the length of `a`.
 #[inline]
@@ -249,9 +249,9 @@ pub fn zip_map_in_place<FA, FB, M>(a: &mut [FA], b: &[FB], zip_map: M)
     }
 }
 
-/// Writes every sample in buffer `b` to buffer `a`.
+/// Writes every sample in slice `b` to slice `a`.
 ///
-/// **Panics** if the buffer lengths differ.
+/// **Panics** if the slice lengths differ.
 #[inline]
 pub fn write<F>(a: &mut [F], b: &[F])
     where F: Frame,
@@ -259,30 +259,30 @@ pub fn write<F>(a: &mut [F], b: &[F])
     zip_map_in_place(a, b, |_, b| b);
 }
 
-/// Adds every sample in buffer `b` to every sample in buffer `a` respectively.
+/// Adds every sample in slice `b` to every sample in slice `a` respectively.
 #[inline]
-pub fn add_in_place<F>(a: &mut [F], b: &[F])
-    where F: Frame,
+pub fn add_in_place<FA, FB>(a: &mut [FA], b: &[FB])
+    where FA: Frame,
+          FB: Frame<Sample=<FA::Sample as Sample>::Signed, NumChannels=FA::NumChannels>,
 {
-    zip_map_in_place(a, b, |a, b| a.add_frame(b));
+    zip_map_in_place(a, b, |a, b| a.add_amp(b));
 }
 
 /// Scale the amplitude of each frame in `b` by `amp_per_channel` before summing it onto `a`.
 #[inline]
-pub fn add_in_place_with_amp_per_channel<F, A>(a: &mut [F], b: &[F], amp_per_channel: A)
-    where F: Frame,
-          A: Frame<NumChannels=F::NumChannels>,
-          F::Sample: SelectFloat<A::Sample>,
-          A::Sample: FloatSample,
+pub fn add_in_place_with_amp_per_channel<FA, FB, A>(a: &mut [FA], b: &[FB], amp_per_channel: A)
+    where FA: Frame,
+          FB: Frame<Sample=<FA::Sample as Sample>::Signed, NumChannels=FA::NumChannels>,
+          A: Frame<Sample=<FB::Sample as Sample>::Float, NumChannels=FB::NumChannels>,
 {
-    zip_map_in_place(a, b, |af, bf| af.add_frame(bf.zip_map(amp_per_channel, Sample::scale_amp)));
+    zip_map_in_place(a, b, |af, bf| af.add_amp(bf.mul_amp(amp_per_channel)));
 }
 
-/// Mutate every element in buffer `a` while reading from each element from buffer `b` in lock-step
+/// Mutate every element in slice `a` while reading from each element from slice `b` in lock-step
 /// using the given function.
 ///
-/// This function does not check that the buffers are the same length and will panic on
-/// index-out-of-bounds .
+/// This function does not check that the slices are the same length and will crash horrifically on
+/// index-out-of-bounds.
 #[inline]
 unsafe fn zip_map_in_place_unchecked<FA, FB, M>(a: &mut [FA], b: &[FB], mut zip_map: M)
     where FA: Frame,

--- a/tests/buffers.rs
+++ b/tests/buffers.rs
@@ -1,51 +1,51 @@
 extern crate sample;
 
 #[test]
-fn test_add_buffer() {
+fn test_add_slice() {
     let mut a = [[-0.5]; 32];
     let b = [[0.5]; 32];
-    sample::buffer::add_in_place(&mut a, &b);
+    sample::slice::add_in_place(&mut a, &b);
     assert_eq!([[0.0]; 32], a);
 }
 
 #[test]
 #[should_panic]
-fn test_add_buffer_panic() {
+fn test_add_slice_panic() {
     let mut a = [[0.5]; 31];
     let b = [[0.5]; 32];
-    sample::buffer::add_in_place(&mut a, &b);
+    sample::slice::add_in_place(&mut a, &b);
 }
 
 #[test]
-fn test_write_buffer() {
+fn test_write_slice() {
     let mut a = [[0.0]; 32];
     let b = [[1.0]; 32];
-    sample::buffer::write(&mut a, &b);
+    sample::slice::write(&mut a, &b);
     assert_eq!([[1.0]; 32], a);
 }
 
 #[test]
 #[should_panic]
-fn test_write_buffer_panic() {
+fn test_write_slice_panic() {
     let mut a = [[0.0]; 31];
     let b = [[1.0]; 32];
-    sample::buffer::write(&mut a, &b);
+    sample::slice::write(&mut a, &b);
 }
 
 #[test]
-fn test_add_buffer_with_amp_per_channel() {
+fn test_add_slice_with_amp_per_channel() {
     let mut a = [[0.5]; 32];
     let b = [[1.0]; 32];
     let amp = [0.5];
-    sample::buffer::add_in_place_with_amp_per_channel(&mut a, &b, amp);
+    sample::slice::add_in_place_with_amp_per_channel(&mut a, &b, amp);
     assert_eq!([[1.0]; 32], a);
 }
 
 #[test]
 #[should_panic]
-fn test_add_buffer_with_amp_per_channel_panic() {
+fn test_add_slice_with_amp_per_channel_panic() {
     let mut a = [[0.5]; 31];
     let b = [[1.0]; 32];
     let amp = [0.5];
-    sample::buffer::add_in_place_with_amp_per_channel(&mut a, &b, amp);
+    sample::slice::add_in_place_with_amp_per_channel(&mut a, &b, amp);
 }

--- a/tests/signal.rs
+++ b/tests/signal.rs
@@ -11,28 +11,17 @@ fn test_equilibrium() {
 }
 
 #[test]
-fn test_zip_add() {
-    let frames = [[0.0], [0.1], [0.2], [0.3]];
-    let a = frames.iter().cloned();
-    let b = frames.iter().cloned();
-    let added: Vec<_> = a.zip_add(b).collect();
-    assert_eq!(added, vec![[0.0], [0.2], [0.4], [0.6]]);
-}
-
-#[test]
-fn test_zip_mod_amp() {
-    let foo = [[255u8, 186], [64, 32]];
-    let bar = [[0.0, 0.5], [-1.0, -0.25]];
-    let a = foo.iter().cloned();
-    let b = bar.iter().cloned();
-    let amp_modulated: Vec<_> = a.zip_mod_amp(b).collect();
-    assert_eq!(amp_modulated, vec![[128, 157], [192, 152]]);
-}
-
-#[test]
 fn test_scale_amp() {
     let foo = [[0.5], [0.8], [-0.4], [-0.2]];
     let amp = 0.5;
     let amp_scaled: Vec<_> = foo.iter().cloned().scale_amp(amp).collect();
     assert_eq!(amp_scaled, vec![[0.25], [0.4], [-0.2], [-0.1]]);
+}
+
+#[test]
+fn test_offset_amp() {
+    let foo = [[0.5], [0.9], [-0.4], [-0.2]];
+    let amp = -0.5;
+    let amp_offset: Vec<_> = foo.iter().cloned().offset_amp(amp).collect();
+    assert_eq!(amp_offset, vec![[0.0], [0.4], [-0.9], [-0.7]]);
 }

--- a/tests/signal.rs
+++ b/tests/signal.rs
@@ -1,0 +1,38 @@
+//! Tests for the `Signal` trait.
+
+extern crate sample;
+
+use sample::Signal;
+
+#[test]
+fn test_equilibrium() {
+    let equilibrium: Vec<[i8; 1]> = sample::signal::equilibrium().take(4).collect();
+    assert_eq!(equilibrium, vec![[0], [0], [0], [0]]);
+}
+
+#[test]
+fn test_zip_add() {
+    let frames = [[0.0], [0.1], [0.2], [0.3]];
+    let a = frames.iter().cloned();
+    let b = frames.iter().cloned();
+    let added: Vec<_> = a.zip_add(b).collect();
+    assert_eq!(added, vec![[0.0], [0.2], [0.4], [0.6]]);
+}
+
+#[test]
+fn test_zip_mod_amp() {
+    let foo = [[255u8, 186], [64, 32]];
+    let bar = [[0.0, 0.5], [-1.0, -0.25]];
+    let a = foo.iter().cloned();
+    let b = bar.iter().cloned();
+    let amp_modulated: Vec<_> = a.zip_mod_amp(b).collect();
+    assert_eq!(amp_modulated, vec![[128, 157], [192, 152]]);
+}
+
+#[test]
+fn test_scale_amp() {
+    let foo = [[0.5], [0.8], [-0.4], [-0.2]];
+    let amp = 0.5;
+    let amp_scaled: Vec<_> = foo.iter().cloned().scale_amp(amp).collect();
+    assert_eq!(amp_scaled, vec![[0.25], [0.4], [-0.2], [-0.1]]);
+}


### PR DESCRIPTION
Also introduces the convention where

- `add_amp`, `mul_amp` are used when operating on the amp of two of the same kinds 
- `offset_amp`, `scale_amp` are used when operating on the amp of a higher kind with a lower kind.