### PR TITLE
Add no_std feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: rust
+rust:
+- stable
+- beta
+- nightly
 os:
 - linux
 env:
   global:
     secure: br54RjnCMOuprqRZa58Yu1fyMQyvwQ7vnj6dqduN5469TontyImmqA8usSuGDLHLkvihAwNspfey7y3UaZIsRqUjfefp2sW6ACccVlC4IiQRgnCi3vmPoqkicUPvDKjzNMVRqTVdJ4CET/gM2OMRhD5rE+sgHegTttC8QTObvT4=
 script:
+- | 
+  ([ "$TRAVIS_RUST_VERSION" = "nightly" ] && cargo build -v --features 'no_std') || [ "$TRAVIS_RUST_VERSION" != "nightly" ]
 - cargo build -v
 - cargo test -v
 - cargo test --release -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "sample"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.5.0"
+version = "0.5.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ homepage = "https://github.com/RustAudio/sample"
 find_folder = "0.3.0"
 hound = "1.1.0"
 portaudio = "0.6.3"
+
+[features]
+no_std = []

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ The **rate** module provides a **Converter** type, for converting and
 interpolating the rate of **Signal**s. This can be useful for both sample rate
 conversion and playback rate multiplication.
 
+Using in a `no_std` environment
+-------------------------------
+
+This crate is largely dependency free, even of things outside `core`. The
+`no_std` cargo feature will enable using `sample` in these environments.
+Currently, only nightly is supported, because it explicitly depends on the
+`alloc` and `collections` for datastructures and `core_intrinsics` for some of
+the math. If this restriction is onerous for you, it can be lifted with minor
+loss of functionality (the `Signal::bus` method), so open an issue!
 
 Contributions
 -------------

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -11,7 +11,7 @@
 //! or any of the custom `I24`, `U24`, `I48` and `U48` types.
 
 use {Frame, Sample};
-use std;
+use core;
 use types::{I24, U24, I48, U48};
 
 
@@ -851,7 +851,7 @@ macro_rules! impl_from_slice_conversions {
                         let new_len = len / $N;
                         let ptr = slice.as_ptr() as *const _;
                         let new_slice = unsafe {
-                            std::slice::from_raw_parts(ptr, new_len)
+                            core::slice::from_raw_parts(ptr, new_len)
                         };
                         Some(new_slice)
                     } else {
@@ -871,7 +871,7 @@ macro_rules! impl_from_slice_conversions {
                         let new_len = len / $N;
                         let ptr = slice.as_ptr() as *mut _;
                         let new_slice = unsafe {
-                            std::slice::from_raw_parts_mut(ptr, new_len)
+                            core::slice::from_raw_parts_mut(ptr, new_len)
                         };
                         Some(new_slice)
                     } else {
@@ -888,7 +888,7 @@ macro_rules! impl_from_slice_conversions {
                     let new_len = slice.len() * $N;
                     let ptr = slice.as_ptr() as *const _;
                     unsafe {
-                        std::slice::from_raw_parts(ptr, new_len)
+                        core::slice::from_raw_parts(ptr, new_len)
                     }
                 }
             }
@@ -901,7 +901,7 @@ macro_rules! impl_from_slice_conversions {
                     let new_len = slice.len() * $N;
                     let ptr = slice.as_ptr() as *mut _;
                     unsafe {
-                        std::slice::from_raw_parts_mut(ptr, new_len)
+                        core::slice::from_raw_parts_mut(ptr, new_len)
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,33 @@
 //! - See the [**rate** module](./rate/index.html) for sample rate conversion and scaling.
 
 #![recursion_limit="512"]
+#![cfg_attr(feature = "no_std", no_std)]
+#![cfg_attr(feature = "no_std", feature(alloc, collections, core_intrinsics))]
+
+#[cfg(not(feature = "no_std"))]
+extern crate core;
+
+#[cfg(feature = "no_std")]
+extern crate alloc;
+
+#[cfg(feature = "no_std")]
+#[macro_use]
+extern crate collections;
+
+#[cfg(feature = "no_std")]
+type Vec<T> = collections::vec::Vec<T>;
+#[cfg(not(feature = "no_std"))]
+type Vec<T> = std::vec::Vec<T>;
+
+#[cfg(feature = "no_std")]
+type VecDeque<T> = collections::vec_deque::VecDeque<T>;
+#[cfg(not(feature = "no_std"))]
+type VecDeque<T> = std::collections::vec_deque::VecDeque<T>;
+
+#[cfg(feature = "no_std")]
+type Rc<T> = alloc::rc::Rc<T>;
+#[cfg(not(feature = "no_std"))]
+type Rc<T> = std::rc::Rc<T>;
 
 pub use conv::{
     FromSample, ToSample, Duplex,
@@ -28,6 +55,24 @@ pub mod frame;
 pub mod signal;
 pub mod rate;
 pub mod types;
+
+#[cfg(feature = "no_std")]
+fn floor(x: f64) -> f64 {
+    unsafe { core::intrinsics::floorf64(x) }
+}
+#[cfg(not(feature = "no_std"))]
+fn floor(x: f64) -> f64 {
+    x.floor()
+}
+
+#[cfg(feature = "no_std")]
+fn sin(x: f64) -> f64 {
+    unsafe { core::intrinsics::sinf64(x) }
+}
+#[cfg(not(feature = "no_std"))]
+fn sin(x: f64) -> f64 {
+    x.sin()
+}
 
 /// A trait for working generically across different **Sample** format types.
 ///
@@ -245,9 +290,9 @@ impl_sample!{
 /// **Sample**s often need to be converted to some mutual **SignedSample** type for signal
 /// addition.
 pub trait SignedSample: Sample
-    + std::ops::Add<Output=Self>
-    + std::ops::Sub<Output=Self>
-    + std::ops::Neg<Output=Self> {}
+    + core::ops::Add<Output=Self>
+    + core::ops::Sub<Output=Self>
+    + core::ops::Neg<Output=Self> {}
 macro_rules! impl_signed_sample { ($($T:ty)*) => { $( impl SignedSample for $T {} )* } }
 impl_signed_sample!(i8 i16 I24 i32 I48 i64 f32 f64);
 
@@ -256,7 +301,7 @@ impl_signed_sample!(i8 i16 I24 i32 I48 i64 f32 f64);
 /// **Sample**s often need to be converted to some mutual **FloatSample** type for signal scaling
 /// and modulation.
 pub trait FloatSample: SignedSample
-    + std::ops::Mul<Output=Self>
-    + std::ops::Div<Output=Self> {}
+    + core::ops::Mul<Output=Self>
+    + core::ops::Div<Output=Self> {}
 impl FloatSample for f32 {}
 impl FloatSample for f64 {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -49,7 +49,7 @@ macro_rules! impl_froms {
 
 macro_rules! impl_neg {
     ($T:ident) => {
-        impl ::std::ops::Neg for $T {
+        impl ::core::ops::Neg for $T {
             type Output = $T;
             #[inline]
             fn neg(self) -> $T {
@@ -129,7 +129,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Add<$T> for $T {
+        impl ::core::ops::Add<$T> for $T {
             type Output = $T;
             #[inline]
             fn add(self, other: Self) -> Self {
@@ -141,7 +141,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Sub<$T> for $T {
+        impl ::core::ops::Sub<$T> for $T {
             type Output = $T;
             #[inline]
             fn sub(self, other: Self) -> Self {
@@ -153,7 +153,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Mul<$T> for $T {
+        impl ::core::ops::Mul<$T> for $T {
             type Output = $T;
             #[inline]
             fn mul(self, other: Self) -> Self {
@@ -165,7 +165,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Div<$T> for $T {
+        impl ::core::ops::Div<$T> for $T {
             type Output = $T;
             #[inline]
             fn div(self, other: Self) -> Self {
@@ -173,7 +173,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Not for $T {
+        impl ::core::ops::Not for $T {
             type Output = $T;
             #[inline]
             fn not(self) -> $T {
@@ -181,7 +181,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Rem<$T> for $T {
+        impl ::core::ops::Rem<$T> for $T {
             type Output = $T;
             #[inline]
             fn rem(self, other: Self) -> Self {
@@ -189,7 +189,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Shl<$T> for $T {
+        impl ::core::ops::Shl<$T> for $T {
             type Output = $T;
             #[inline]
             fn shl(self, other: Self) -> Self {
@@ -198,7 +198,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::Shr<$T> for $T {
+        impl ::core::ops::Shr<$T> for $T {
             type Output = $T;
             #[inline]
             fn shr(self, other: Self) -> Self {
@@ -207,7 +207,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::BitAnd<$T> for $T {
+        impl ::core::ops::BitAnd<$T> for $T {
             type Output = $T;
             #[inline]
             fn bitand(self, other: Self) -> Self {
@@ -215,7 +215,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::BitOr<$T> for $T {
+        impl ::core::ops::BitOr<$T> for $T {
             type Output = $T;
             #[inline]
             fn bitor(self, other: Self) -> Self {
@@ -223,7 +223,7 @@ macro_rules! new_sample_type {
             }
         }
 
-        impl ::std::ops::BitXor<$T> for $T {
+        impl ::core::ops::BitXor<$T> for $T {
             type Output = $T;
             #[inline]
             fn bitxor(self, other: Self) -> Self {


### PR DESCRIPTION
This adds the ability to use this crate in `no_std` environments, provided
that memory allocation (the `alloc` and `collections` crates) are available.