### PR TITLE
Replace the "no_std" Cargo feature with a default "std" feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
     secure: br54RjnCMOuprqRZa58Yu1fyMQyvwQ7vnj6dqduN5469TontyImmqA8usSuGDLHLkvihAwNspfey7y3UaZIsRqUjfefp2sW6ACccVlC4IiQRgnCi3vmPoqkicUPvDKjzNMVRqTVdJ4CET/gM2OMRhD5rE+sgHegTttC8QTObvT4=
 script:
 - | 
-  ([ "$TRAVIS_RUST_VERSION" = "nightly" ] && cargo build -v --features 'no_std') || [ "$TRAVIS_RUST_VERSION" != "nightly" ]
+  ([ "$TRAVIS_RUST_VERSION" = "nightly" ] && cargo build -v --no-default-features) || [ "$TRAVIS_RUST_VERSION" != "nightly" ]
 - cargo build -v
 - cargo test -v
 - cargo test --release -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ hound = "1.1.0"
 portaudio = "0.6.3"
 
 [features]
-no_std = []
+default = ["std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,32 +9,32 @@
 //! - See the [**rate** module](./rate/index.html) for sample rate conversion and scaling.
 
 #![recursion_limit="512"]
-#![cfg_attr(feature = "no_std", no_std)]
-#![cfg_attr(feature = "no_std", feature(alloc, collections, core_intrinsics))]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc, collections, core_intrinsics))]
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 extern crate core;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 #[macro_use]
 extern crate collections;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 type Vec<T> = collections::vec::Vec<T>;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 type Vec<T> = std::vec::Vec<T>;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 type VecDeque<T> = collections::vec_deque::VecDeque<T>;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 type VecDeque<T> = std::collections::vec_deque::VecDeque<T>;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 type Rc<T> = alloc::rc::Rc<T>;
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 type Rc<T> = std::rc::Rc<T>;
 
 pub use conv::{
@@ -56,20 +56,20 @@ pub mod signal;
 pub mod rate;
 pub mod types;
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 fn floor(x: f64) -> f64 {
     unsafe { core::intrinsics::floorf64(x) }
 }
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn floor(x: f64) -> f64 {
     x.floor()
 }
 
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 fn sin(x: f64) -> f64 {
     unsafe { core::intrinsics::sinf64(x) }
 }
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn sin(x: f64) -> f64 {
     x.sin()
 }


### PR DESCRIPTION
Since Cargo will use the union of all requested features for a crate which is referenced multiple times, it is better to have features that enable things rather than disable them. Otherwise, the inclusion of an unrelated crate that doesn't rely on that feature can break a crate that does rely on that feature.