### PR TITLE
Implement windowing for signals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod frame;
 pub mod signal;
 pub mod rate;
 pub mod types;
+pub mod window;
 
 #[cfg(not(feature = "std"))]
 fn floor(x: f64) -> f64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,12 +67,30 @@ fn floor(x: f64) -> f64 {
 }
 
 #[cfg(not(feature = "std"))]
+fn ceil(x: f64) -> f64 {
+    unsafe { core::intrinsics::ceilf64(x) }
+}
+#[cfg(feature = "std")]
+fn ceil(x: f64) -> f64 {
+    x.ceil()
+}
+
+#[cfg(not(feature = "std"))]
 fn sin(x: f64) -> f64 {
     unsafe { core::intrinsics::sinf64(x) }
 }
 #[cfg(feature = "std")]
 fn sin(x: f64) -> f64 {
     x.sin()
+}
+
+#[cfg(not(feature = "std"))]
+fn cos(x: f64) -> f64 {
+    unsafe { core::intrinsics::cosf64(x) }
+}
+#[cfg(feature = "std")]
+fn cos(x: f64) -> f64 {
+    x.cos()
 }
 
 /// A trait for working generically across different **Sample** format types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ fn cos(x: f64) -> f64 {
     x.cos()
 }
 
+#[cfg(not(feature = "std"))]
 fn sqrt_f32(x: f32) -> f32 {
     unsafe { core::intrinsics::sqrtf32(x) }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -40,7 +40,7 @@ pub struct Window<S: Sample, T: Step, F: Frame<Sample=S>, WT: WindowType<S, T>> 
 
 impl<S: Sample, F: Frame<Sample=S>, WT: WindowType<S, ConstHz>> Window<S, ConstHz, F, WT> {
     pub fn new(len: usize) -> Self {
-        let step = signal::rate(len as f64).const_hz(1.);
+        let step = signal::rate(len as f64 - 1.).const_hz(1.);
         Window {
             phase: signal::phase(step),
             stype: PhantomData,
@@ -81,9 +81,8 @@ impl<'a, S: Sample<Float=S> + FloatSample + FromSample<f64>, T: Step, F: 'a + Fr
 
     fn next(&mut self) -> Option<Self::Item> {
         self.window.next().and_then(|v| {
-            let out = self.data.get(self.idx).and_then(|d| {
-                Some(v.mul_amp(*d))
-            });
+            let out = self.data.get(self.idx)
+                .and_then(|d| Some(v.mul_amp(*d)));
             self.idx += 1;
             out
         })

--- a/src/window.rs
+++ b/src/window.rs
@@ -54,7 +54,7 @@ pub struct Windower<'a, S, F, WT>
 impl<S: Sample + ToSample<f64> + FromSample<f64>> Type<S> for Hanning {
     fn at_phase(phase: S) -> S {
         let v = phase.to_sample::<f64>() * f64::consts::PI * 2.;
-        (0.5f64 * (1f64 - v.cos())).to_sample::<S>()
+        (0.5f64 * (1f64 - super::cos(v))).to_sample::<S>()
     }
 }
 
@@ -159,7 +159,7 @@ impl<'a, S, F, WT> Iterator for Windower<'a, S, F, WT>
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let rem = (self.data.len() - self.idx) - (self.bin - self.hop);
-        ((rem as f64 / self.hop as f64).ceil() as usize, None)
+        (super::ceil(rem as f64 / self.hop as f64) as usize, None)
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,47 +1,139 @@
 use core::marker::PhantomData;
 use core::f64;
 
-use Sample;
+use {Sample, FloatSample};
 use signal;
 use signal::{Phase, ConstHz, Step};
 use conv::{FromSample, ToSample};
+use frame::Frame;
 
 // Using types instead of enum allows for static dispatch
-pub trait WindowType<E: Step, S: Sample> {
+pub trait WindowType<S: Sample, T: Step> {
     fn at_phase(phase: S) -> S;
 }
 
 pub struct HanningWindow;
 
-impl<E: Step, S: Sample + ToSample<f64> + FromSample<f64>> WindowType<E, S> for HanningWindow {
+impl<S: Sample + ToSample<f64> + FromSample<f64>, T: Step> WindowType<S, T> for HanningWindow {
     fn at_phase(phase: S) -> S {
         let v = phase.to_sample::<f64>() * f64::consts::PI * 2.;
         (0.5f64 * (1f64 - v.cos())).to_sample::<S>()
     }
 }
 
-pub struct Window<S: Sample, T: WindowType<ConstHz, S>> {
-    pub phase: Phase<ConstHz>,
-    wtype: PhantomData<T>,
-    stype: PhantomData<S>
+pub struct RectangleWindow;
+
+impl<S: Sample + FromSample<f64>, T: Step> WindowType<S, T> for RectangleWindow {
+    #[allow(unused)]
+    fn at_phase(phase: S) -> S {
+        (1.).to_sample::<S>()
+    }
 }
 
-impl<S: Sample, T: WindowType<ConstHz, S>> Window<S, T> {
-    pub fn new(len: usize) -> Window<S, T> {
+pub struct Window<S: Sample, T: Step, F: Frame<Sample=S>, WT: WindowType<S, T>> {
+    pub phase: Phase<ConstHz>,
+    stype: PhantomData<S>,
+    ttype: PhantomData<T>,
+    ftype: PhantomData<F>,
+    wttype: PhantomData<WT>
+}
+
+impl<S: Sample, F: Frame<Sample=S>, WT: WindowType<S, ConstHz>> Window<S, ConstHz, F, WT> {
+    pub fn new(len: usize) -> Self {
         let step = signal::rate(len as f64).const_hz(1.);
         Window {
             phase: signal::phase(step),
-            wtype: PhantomData,
-            stype: PhantomData
+            stype: PhantomData,
+            ttype: PhantomData,
+            ftype: PhantomData,
+            wttype: PhantomData
         }
     }
 }
 
-impl<S: Sample + FromSample<f64>, T: WindowType<ConstHz, S>> Iterator for Window<S, T> {
-    type Item = [S; 1];
+impl<S: Sample + FromSample<f64>, F: Frame<Sample=S>, T: Step, WT: WindowType<S, T>> Iterator for Window<S, T, F, WT> {
+    type Item = F;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some([T::at_phase((self.phase.next_phase()).to_sample::<S>())])
+        let v = WT::at_phase((self.phase.next_phase()).to_sample::<S>());
+        Some(F::from_fn(|_| v))
+    }
+}
+
+pub struct WindowedFrame<'a, S: Sample + FromSample<f64>, T: Step, F: 'a + Frame<Sample=S>, WT: WindowType<S, T>> {
+    pub data: &'a [F],
+    pub window: Window<S, T, F, WT>,
+    idx: usize
+}
+
+impl<'a, S: Sample + FromSample<f64>, T: Step, F: 'a + Frame<Sample=S>, WT: WindowType<S, T>> WindowedFrame<'a, S, T, F, WT> {
+    pub fn new(data: &'a [F], window: Window<S, T, F, WT>) -> Self {
+        WindowedFrame {
+            data: data,
+            window: window,
+            idx: 0
+        }
+    }
+}
+
+impl<'a, S: Sample<Float=S> + FloatSample + FromSample<f64>, T: Step, F: 'a + Frame<Sample=S::Float>, WT: WindowType<S, T>> Iterator for WindowedFrame<'a, S, T, F, WT> {
+    type Item = F;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.window.next().and_then(|v| {
+            let out = self.data.get(self.idx).and_then(|d| {
+                Some(v.mul_amp(*d))
+            });
+            self.idx += 1;
+            out
+        })
+    }
+}
+
+/// Windower takes a long slice of data and generates an iterator over its frames
+pub struct Windower<'a, S: Sample + FromSample<f64>, T: Step, F: 'a + Frame<Sample=S>, WT: WindowType<S, T>> {
+    pub bin: usize,
+    pub hop: usize,
+    pub idx: usize,
+    pub data: &'a [F],
+    stype: PhantomData<S>,
+    ttype: PhantomData<T>,
+    wttype: PhantomData<WT>
+}
+
+impl<'a, S: Sample + FromSample<f64>, T: Step, F: 'a + Frame<Sample=S>, WT: WindowType<S, T>> Windower<'a, S, T, F, WT> {
+    /// Providing some reasonable defaults of bin = 512, hop = 256
+    pub fn new(data: &'a [F]) -> Self {
+        Windower {
+            bin: 512,
+            hop: 256,
+            idx: 0,
+            data: data,
+            stype: PhantomData,
+            ttype: PhantomData,
+            wttype: PhantomData
+        }
+    }
+}
+
+impl<'a, S: Sample + FromSample<f64>, F: 'a + Frame<Sample=S>, WT: WindowType<S, ConstHz>> Iterator for Windower<'a, S, ConstHz, F, WT> {
+    type Item = WindowedFrame<'a, S, ConstHz, F, WT>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let top = self.idx + self.bin;
+        if top < self.data.len() {
+            let data = &self.data[self.idx..top];
+            let window: Window<S, ConstHz, F, WT> = Window::new(self.bin);
+            self.idx += self.hop;
+            Some(WindowedFrame::new(data, window))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = (self.data.len() - self.idx) - (self.bin - self.hop);
+        ((rem as f64 / self.hop as f64).ceil() as usize, None)
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,0 +1,47 @@
+use core::marker::PhantomData;
+use core::f64;
+
+use Sample;
+use signal;
+use signal::{Phase, ConstHz, Step};
+use conv::{FromSample, ToSample};
+
+// Using types instead of enum allows for static dispatch
+pub trait WindowType<E: Step, S: Sample> {
+    fn at_phase(phase: S) -> S;
+}
+
+pub struct HanningWindow;
+
+impl<E: Step, S: Sample + ToSample<f64> + FromSample<f64>> WindowType<E, S> for HanningWindow {
+    fn at_phase(phase: S) -> S {
+        let v = phase.to_sample::<f64>() * f64::consts::PI * 2.;
+        (0.5f64 * (1f64 - v.cos())).to_sample::<S>()
+    }
+}
+
+pub struct Window<S: Sample, T: WindowType<ConstHz, S>> {
+    pub phase: Phase<ConstHz>,
+    wtype: PhantomData<T>,
+    stype: PhantomData<S>
+}
+
+impl<S: Sample, T: WindowType<ConstHz, S>> Window<S, T> {
+    pub fn new(len: usize) -> Window<S, T> {
+        let step = signal::rate(len as f64).const_hz(1.);
+        Window {
+            phase: signal::phase(step),
+            wtype: PhantomData,
+            stype: PhantomData
+        }
+    }
+}
+
+impl<S: Sample + FromSample<f64>, T: WindowType<ConstHz, S>> Iterator for Window<S, T> {
+    type Item = [S; 1];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Some([T::at_phase((self.phase.next_phase()).to_sample::<S>())])
+    }
+}
+

--- a/src/window.rs
+++ b/src/window.rs
@@ -126,11 +126,10 @@ impl<'a, S, F, WT> Windower<'a, S, F, WT>
           F: 'a + Frame<Sample=S>, 
           WT: Type<S>
 {
-    /// Providing some reasonable defaults of bin = 512, hop = 256
-    pub fn new(data: &'a [F]) -> Self {
+    pub fn new(data: &'a [F], bin: usize, hop: usize) -> Self {
         Windower {
-            bin: 512,
-            hop: 256,
+            bin: bin,
+            hop: hop,
             idx: 0,
             data: data,
             stype: PhantomData,
@@ -162,5 +161,19 @@ impl<'a, S, F, WT> Iterator for Windower<'a, S, F, WT>
         let rem = (self.data.len() - self.idx) - (self.bin - self.hop);
         ((rem as f64 / self.hop as f64).ceil() as usize, None)
     }
+}
+
+pub fn hanning<S, F>(len: usize) -> Window<S, F, Hanning> 
+    where S: Sample + FromSample<f64> + ToSample<f64>, 
+          F: Frame<Sample=S>
+{
+    Window::new(len)
+}
+
+pub fn rectangle<S, F>(len: usize) -> Window<S, F, Rectangle> 
+    where S: Sample + FromSample<f64>, 
+          F: Frame<Sample=S>
+{
+    Window::new(len)
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -104,8 +104,8 @@ impl<'a, F, WT> WindowedFrame<'a, F, WT>
 }
 
 impl<'a, F, WT> Iterator for WindowedFrame<'a, F, WT> 
-    where F: 'a + Frame<Sample=<<F as Frame>::Sample as Sample>::Float>, 
-          F::Sample: FloatSample + FromSample<f64>, 
+    where F: 'a + Frame, 
+          <F as Frame>::Sample: FloatSample<Float=F::Sample> + FromSample<f64>, 
           WT: Type<F::Sample>
 {
     type Item = F;

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -1,0 +1,14 @@
+extern crate sample;
+
+use sample::signal::ConstHz;
+use sample::window::{Window, HanningWindow, WindowType};
+
+#[test]
+fn test_window_at_phase() {
+    let mut window: Window<f64, HanningWindow> = Window::new(8);
+    let exp = [0., 0.1464, 0.5000, 0.8536];
+    for (r, e) in window.zip(exp.iter()) {
+        println!("Exp: {}\t\tFound: {}", e, r[0]);
+        assert!((r[0] - e).abs() < 0.001);
+    }
+}

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -5,7 +5,7 @@ use sample::window::{Windower, Rectangle};
 
 #[test]
 fn test_window_at_phase() {
-    let mut window = sample::window::hanning::<f64, [f64; 1]>(9);
+    let window = sample::window::hanning::<[f64; 1]>(9);
     let exp = [0., 0.1464, 0.5000, 0.8536, 1., 0.8536, 0.5000, 0.1464, 0., 0.1464];
     for (r, e) in window.zip(exp.iter()) {
         println!("Exp: {}\t\tFound: {}", e, r[0]);
@@ -18,7 +18,7 @@ fn test_windower() {
     let data: [[f64; 1]; 8] = [[0.1], [0.1], [0.2], [0.2], [0.3], [0.3], [0.4], [0.4]];
     let exp = [[[0.1], [0.1]], [[0.1], [0.2]], [[0.2], [0.2]], [[0.2], [0.3]], [[0.3], [0.3]], [[0.3], [0.4]], [[0.4], [0.4]]];
 
-    let mut windower: Windower<f64, [f64; 1], Rectangle> = Windower::new(&data, 2, 1);
+    let windower: Windower<[f64; 1], Rectangle> = Windower::new(&data, 2, 1);
     for (re, ex) in windower.zip(exp.iter()) {
         for (r, e) in re.zip(ex.iter()) {
             for (r_chan, e_chan) in r.channels().zip(e.channels()) {

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -1,12 +1,11 @@
 extern crate sample;
 
 use sample::frame::Frame;
-use sample::signal::ConstHz;
-use sample::window::{Window, Windower, HanningWindow, RectangleWindow, WindowType};
+use sample::window::{Window, Windower, Hanning, Rectangle};
 
 #[test]
 fn test_window_at_phase() {
-    let mut window: Window<f64, ConstHz, [f64; 1], HanningWindow> = Window::new(9);
+    let mut window: Window<f64, [f64; 1], Hanning> = Window::new(9);
     let exp = [0., 0.1464, 0.5000, 0.8536, 1., 0.8536, 0.5000, 0.1464, 0., 0.1464];
     for (r, e) in window.zip(exp.iter()) {
         println!("Exp: {}\t\tFound: {}", e, r[0]);
@@ -19,7 +18,7 @@ fn test_windower() {
     let data: [[f64; 1]; 8] = [[0.1], [0.1], [0.2], [0.2], [0.3], [0.3], [0.4], [0.4]];
     let exp = [[[0.1], [0.1]], [[0.1], [0.2]], [[0.2], [0.2]], [[0.2], [0.3]], [[0.3], [0.3]], [[0.3], [0.4]], [[0.4], [0.4]]];
 
-    let mut windower: Windower<f64, ConstHz, [f64; 1], RectangleWindow> = Windower::new(&data);
+    let mut windower: Windower<f64, [f64; 1], Rectangle> = Windower::new(&data);
     windower.bin = 2;
     windower.hop = 1;
     for (re, ex) in windower.zip(exp.iter()) {

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -1,11 +1,11 @@
 extern crate sample;
 
 use sample::frame::Frame;
-use sample::window::{Window, Windower, Hanning, Rectangle};
+use sample::window::{Windower, Rectangle};
 
 #[test]
 fn test_window_at_phase() {
-    let mut window: Window<f64, [f64; 1], Hanning> = Window::new(9);
+    let mut window = sample::window::hanning::<f64, [f64; 1]>(9);
     let exp = [0., 0.1464, 0.5000, 0.8536, 1., 0.8536, 0.5000, 0.1464, 0., 0.1464];
     for (r, e) in window.zip(exp.iter()) {
         println!("Exp: {}\t\tFound: {}", e, r[0]);
@@ -18,9 +18,7 @@ fn test_windower() {
     let data: [[f64; 1]; 8] = [[0.1], [0.1], [0.2], [0.2], [0.3], [0.3], [0.4], [0.4]];
     let exp = [[[0.1], [0.1]], [[0.1], [0.2]], [[0.2], [0.2]], [[0.2], [0.3]], [[0.3], [0.3]], [[0.3], [0.4]], [[0.4], [0.4]]];
 
-    let mut windower: Windower<f64, [f64; 1], Rectangle> = Windower::new(&data);
-    windower.bin = 2;
-    windower.hop = 1;
+    let mut windower: Windower<f64, [f64; 1], Rectangle> = Windower::new(&data, 2, 1);
     for (re, ex) in windower.zip(exp.iter()) {
         for (r, e) in re.zip(ex.iter()) {
             for (r_chan, e_chan) in r.channels().zip(e.channels()) {

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -6,8 +6,8 @@ use sample::window::{Window, Windower, HanningWindow, RectangleWindow, WindowTyp
 
 #[test]
 fn test_window_at_phase() {
-    let mut window: Window<f64, ConstHz, [f64; 1], HanningWindow> = Window::new(8);
-    let exp = [0., 0.1464, 0.5000, 0.8536];
+    let mut window: Window<f64, ConstHz, [f64; 1], HanningWindow> = Window::new(9);
+    let exp = [0., 0.1464, 0.5000, 0.8536, 1., 0.8536, 0.5000, 0.1464, 0., 0.1464];
     for (r, e) in window.zip(exp.iter()) {
         println!("Exp: {}\t\tFound: {}", e, r[0]);
         assert!((r[0] - e).abs() < 0.001);

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -1,14 +1,33 @@
 extern crate sample;
 
+use sample::frame::Frame;
 use sample::signal::ConstHz;
-use sample::window::{Window, HanningWindow, WindowType};
+use sample::window::{Window, Windower, HanningWindow, RectangleWindow, WindowType};
 
 #[test]
 fn test_window_at_phase() {
-    let mut window: Window<f64, HanningWindow> = Window::new(8);
+    let mut window: Window<f64, ConstHz, [f64; 1], HanningWindow> = Window::new(8);
     let exp = [0., 0.1464, 0.5000, 0.8536];
     for (r, e) in window.zip(exp.iter()) {
         println!("Exp: {}\t\tFound: {}", e, r[0]);
         assert!((r[0] - e).abs() < 0.001);
+    }
+}
+
+#[test]
+fn test_windower() {
+    let data: [[f64; 1]; 8] = [[0.1], [0.1], [0.2], [0.2], [0.3], [0.3], [0.4], [0.4]];
+    let exp = [[[0.1], [0.1]], [[0.1], [0.2]], [[0.2], [0.2]], [[0.2], [0.3]], [[0.3], [0.3]], [[0.3], [0.4]], [[0.4], [0.4]]];
+
+    let mut windower: Windower<f64, ConstHz, [f64; 1], RectangleWindow> = Windower::new(&data);
+    windower.bin = 2;
+    windower.hop = 1;
+    for (re, ex) in windower.zip(exp.iter()) {
+        for (r, e) in re.zip(ex.iter()) {
+            for (r_chan, e_chan) in r.channels().zip(e.channels()) {
+                println!("Exp: {}\t\tFound: {}", e_chan, r_chan);
+                assert!((r_chan - e_chan).abs() < 0.001);
+            }
+        }
     }
 }


### PR DESCRIPTION
This implements two basic windowing functions: Hanning and Rectangular windows. It is also possible to window successive frames (with bin/hop) of a longer data stream.