### PR TITLE
[Breaking Change] Add conversions for Boxed slices. Add associated Signed and Float types to Frame trait. Improve some Rate method names and adapt Signal accordingly.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "sample"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.5.1"
+version = "0.6.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -10,9 +10,8 @@
 //! The conversion functions do *not* check the range of incoming values for floating point values
 //! or any of the custom `I24`, `U24`, `I48` and `U48` types.
 
-use {Frame, Sample};
+use {Box, Frame, Sample};
 use core;
-use std;
 use types::{I24, U24, I48, U48};
 
 
@@ -956,9 +955,9 @@ macro_rules! impl_from_slice_conversions {
                     // forgotten so that our slice does not get deallocated.
                     let len = slice.len();
                     let slice_ptr = &mut slice as &mut [S] as *mut [S];
-                    std::mem::forget(slice);
+                    core::mem::forget(slice);
                     let sample_slice = unsafe {
-                        std::slice::from_raw_parts_mut((*slice_ptr).as_mut_ptr(), len)
+                        core::slice::from_raw_parts_mut((*slice_ptr).as_mut_ptr(), len)
                     };
 
                     // Convert to our frame slice if possible.
@@ -1010,11 +1009,11 @@ macro_rules! impl_from_slice_conversions {
                 fn from_boxed_frame_slice(mut slice: Box<[[S; $N]]>) -> Self {
                     let new_len = slice.len() * $N;
                     let frame_slice_ptr = &mut slice as &mut [[S; $N]] as *mut [[S; $N]];
-                    std::mem::forget(slice);
+                    core::mem::forget(slice);
                     let sample_slice_ptr = frame_slice_ptr as *mut [S];
                     unsafe {
                         let ptr = (*sample_slice_ptr).as_mut_ptr();
-                        let sample_slice = std::slice::from_raw_parts_mut(ptr, new_len);
+                        let sample_slice = core::slice::from_raw_parts_mut(ptr, new_len);
                         Box::from_raw(sample_slice as *mut _)
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,9 +41,11 @@ pub use conv::{
     FromSample, ToSample, Duplex,
     FromSampleSlice, ToSampleSlice, DuplexSampleSlice,
     FromSampleSliceMut, ToSampleSliceMut, DuplexSampleSliceMut,
+    FromBoxedSampleSlice, ToBoxedSampleSlice, DuplexBoxedSampleSlice,
     FromFrameSlice, ToFrameSlice, DuplexFrameSlice,
     FromFrameSliceMut, ToFrameSliceMut, DuplexFrameSliceMut,
-    DuplexSlice, DuplexSliceMut,
+    FromBoxedFrameSlice, ToBoxedFrameSlice, DuplexBoxedFrameSlice,
+    DuplexSlice, DuplexSliceMut, DuplexBoxedSlice,
 };
 pub use frame::Frame;
 pub use signal::Signal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,24 @@ fn sin(x: f64) -> f64 {
     x.sin()
 }
 
+#[cfg(not(feature = "std"))]
+fn sqrt_f32(x: f32) -> f32 {
+    unsafe { core::intrinsics::sqrtf32(x) }
+}
+#[cfg(feature = "std")]
+fn sqrt_f32(x: f32) -> f32 {
+    x.sqrt()
+}
+
+#[cfg(not(feature = "std"))]
+fn sqrt_f64(x: f64) -> f64 {
+    unsafe { core::intrinsics::sqrt(f64) }
+}
+#[cfg(feature = "std")]
+fn sqrt_f64(x: f64) -> f64 {
+    x.sqrt()
+}
+
 /// A trait for working generically across different **Sample** format types.
 ///
 /// Provides methods for converting to and from any type that implements the
@@ -386,12 +404,12 @@ impl FloatSample for f32 {
     #[inline]
     fn identity() -> Self { 1.0 }
     #[inline]
-    fn sample_sqrt(self) -> Self { self.sqrt() }
+    fn sample_sqrt(self) -> Self { sqrt_f32(self) }
 }
 
 impl FloatSample for f64 {
     #[inline]
     fn identity() -> Self { 1.0 }
     #[inline]
-    fn sample_sqrt(self) -> Self { self.sqrt() }
+    fn sample_sqrt(self) -> Self { sqrt_f64(self) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ fn sqrt_f32(x: f32) -> f32 {
 
 #[cfg(not(feature = "std"))]
 fn sqrt_f64(x: f64) -> f64 {
-    unsafe { core::intrinsics::sqrt(f64) }
+    unsafe { core::intrinsics::sqrtf64(x) }
 }
 #[cfg(feature = "std")]
 fn sqrt_f64(x: f64) -> f64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,11 @@ type VecDeque<T> = collections::vec_deque::VecDeque<T>;
 type VecDeque<T> = std::collections::vec_deque::VecDeque<T>;
 
 #[cfg(not(feature = "std"))]
+pub type Box<T> = alloc::boxed::Box<T>;
+#[cfg(feature = "std")]
+pub type Box<T> = std::boxed::Box<T>;
+
+#[cfg(not(feature = "std"))]
 type Rc<T> = alloc::rc::Rc<T>;
 #[cfg(feature = "std")]
 type Rc<T> = std::rc::Rc<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
     }
 
     /// Create a `Self` from any type that implements `ToSample<Self>`.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -216,6 +217,46 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
         where Self: FromSample<S>,
     {
         FromSample::from_sample_(s)
+    }
+
+    /// Converts `self` to the equivalent `Sample` in the associated `Signed` format.
+    ///
+    /// This is a simple wrapper around `Sample::to_sample` which may provide extra convenience in
+    /// some cases, particularly for assisting type inference.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Sample;
+    ///
+    /// fn main() {
+    ///     assert_eq!(128_u8.to_signed_sample(), 0i8);
+    /// }
+    /// ```
+    fn to_signed_sample(self) -> Self::Signed {
+        self.to_sample()
+    }
+
+    /// Converts `self` to the equivalent `Sample` in the associated `Float` format.
+    ///
+    /// This is a simple wrapper around `Sample::to_sample` which may provide extra convenience in
+    /// some cases, particularly for assisting type inference.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate sample;
+    ///
+    /// use sample::Sample;
+    ///
+    /// fn main() {
+    ///     assert_eq!(128_u8.to_float_sample(), 0.0);
+    /// }
+    /// ```
+    fn to_float_sample(self) -> Self::Float {
+        self.to_sample()
     }
 
     /// Adds (or "offsets") the amplitude of the `Sample` by the given signed amplitude.
@@ -238,7 +279,7 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
     /// ```
     #[inline]
     fn add_amp(self, amp: Self::Signed) -> Self {
-        let self_s: Self::Signed = self.to_sample();
+        let self_s = self.to_signed_sample();
         (self_s + amp).to_sample()
     }
 
@@ -268,7 +309,7 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
     /// ```
     #[inline]
     fn mul_amp(self, amp: Self::Float) -> Self {
-        let self_f: Self::Float = self.to_sample();
+        let self_f = self.to_float_sample();
         (self_f * amp).to_sample()
     }
 
@@ -317,7 +358,7 @@ impl_sample!{
 ///
 /// **Sample**s often need to be converted to some mutual **SignedSample** type for signal
 /// addition.
-pub trait SignedSample: Sample
+pub trait SignedSample: Sample<Signed=Self>
     + core::ops::Add<Output=Self>
     + core::ops::Sub<Output=Self>
     + core::ops::Neg<Output=Self> {}
@@ -328,20 +369,29 @@ impl_signed_sample!(i8 i16 I24 i32 I48 i64 f32 f64);
 ///
 /// **Sample**s often need to be converted to some mutual **FloatSample** type for signal scaling
 /// and modulation.
-pub trait FloatSample: SignedSample
+pub trait FloatSample: Sample<Signed=Self, Float=Self>
+    + SignedSample
     + core::ops::Mul<Output=Self>
     + core::ops::Div<Output=Self>
+    + Duplex<f32>
+    + Duplex<f64>
 {
     /// Represents the multiplicative identity of the floating point signal.
     fn identity() -> Self;
+    /// Calculate the square root of `Self`. A convenience generic wrapper around `.sqrt()`.
+    fn sample_sqrt(self) -> Self;
 }
 
 impl FloatSample for f32 {
     #[inline]
     fn identity() -> Self { 1.0 }
+    #[inline]
+    fn sample_sqrt(self) -> Self { self.sqrt() }
 }
 
 impl FloatSample for f64 {
     #[inline]
     fn identity() -> Self { 1.0 }
+    #[inline]
+    fn sample_sqrt(self) -> Self { self.sqrt() }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -210,7 +210,7 @@ pub trait Signal: Iterator + Sized
 
     /// Multiplies the rate at which frames of `self` are yielded by the given `signal`.
     ///
-    /// This happens by wrapping `self` in a `rate::Converter` and calling `set_rate_multiplier`
+    /// This happens by wrapping `self` in a `rate::Converter` and calling `set_playback_hz_scale`
     /// with the value yielded by `signal`
     ///
     /// # Example
@@ -222,7 +222,7 @@ pub trait Signal: Iterator + Sized
     ///
     /// fn main() {
     ///     let foo = [[0.0], [1.0], [0.0], [-1.0]];
-    ///     let mul = [1.0, 1.0, 2.0, 2.0, 2.0, 2.0];
+    ///     let mul = [1.0, 1.0, 0.5, 0.5, 0.5, 0.5];
     ///     let frames: Vec<_> = foo.iter().cloned().mul_hz(mul.iter().cloned()).collect();
     ///     assert_eq!(&frames[..], &[[0.0], [1.0], [0.0], [-0.5], [-1.0]][..]);
     /// }
@@ -231,7 +231,7 @@ pub trait Signal: Iterator + Sized
         where I: Iterator<Item=f64>,
     {
         MulHz {
-            signal: rate::Converter::scale_hz(self, 1.0),
+            signal: rate::Converter::scale_playback_hz(self, 1.0),
             mul_per_frame: mul_per_frame,
         }
     }
@@ -271,7 +271,7 @@ pub trait Signal: Iterator + Sized
     /// }
     /// ```
     fn scale_hz(self, multi: f64) -> rate::Converter<Self> {
-        rate::Converter::scale_hz(self, multi)
+        rate::Converter::scale_playback_hz(self, multi)
     }
 
     /// Delays the `Signal` by the given number of frames.
@@ -531,7 +531,7 @@ pub struct ScaleAmpPerChannel<S, F> {
 
 /// Multiplies the rate at which frames of `self` are yielded by the given `signal`.
 ///
-/// This happens by wrapping `self` in a `rate::Converter` and calling `set_rate_multiplier`
+/// This happens by wrapping `self` in a `rate::Converter` and calling `set_playback_hz_scale`
 /// with the value yielded by `signal`
 #[derive(Clone)]
 pub struct MulHz<S, M>
@@ -1496,7 +1496,7 @@ impl<S, M> Iterator for MulHz<S, M>
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.mul_per_frame.next().and_then(|mul| {
-            self.signal.set_rate_multiplier(mul);
+            self.signal.set_playback_hz_scale(mul);
             self.signal.next()
         })
     }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -2,8 +2,10 @@
 
 use {
     Frame, Sample,
-    ToSampleSlice, ToSampleSliceMut, ToFrameSlice, ToFrameSliceMut,
-    FromSampleSlice, FromSampleSliceMut, FromFrameSlice, FromFrameSliceMut,
+    ToSampleSlice, ToSampleSliceMut, ToBoxedSampleSlice,
+    ToFrameSlice, ToFrameSliceMut, ToBoxedFrameSlice,
+    FromSampleSlice, FromSampleSliceMut, FromBoxedSampleSlice,
+    FromFrameSlice, FromFrameSliceMut, FromBoxedFrameSlice,
 };
 
 
@@ -70,6 +72,35 @@ pub fn to_frame_slice_mut<'a, T, F>(slice: T) -> Option<&'a mut [F]>
     slice.to_frame_slice_mut()
 }
 
+/// Converts the given boxed slice into a boxed slice of `Frame`s.
+///
+/// Returns `None` if the number of channels in a single frame `F` is not a multiple of the number
+/// of samples in the given slice.
+///
+/// This is a convenience function that wraps the `ToBoxedFrameSlice` trait.
+///
+/// # Examples
+///
+/// ```
+/// extern crate sample;
+///
+/// fn main() {
+///     let foo = vec![0.0, 0.5, 0.0, -0.5].into_boxed_slice();
+///     let bar: Box<[[f32; 2]]> = sample::slice::to_boxed_frame_slice(foo).unwrap();
+///     assert_eq!(bar.into_vec(), vec![[0.0, 0.5], [0.0, -0.5]]);
+///
+///     let foo = vec![0.0, 0.5, 0.0].into_boxed_slice();
+///     let bar = sample::slice::to_boxed_frame_slice(foo);
+///     assert_eq!(bar, None::<Box<[[f32; 2]]>>);
+/// }
+/// ```
+pub fn to_boxed_frame_slice<T, F>(slice: T) -> Option<Box<[F]>>
+    where F: Frame,
+          T: ToBoxedFrameSlice<F>,
+{
+    slice.to_boxed_frame_slice()
+}
+
 /// Converts the given slice into a slice of `Sample`s.
 ///
 /// This is a convenience function that wraps the `ToSampleSlice` trait.
@@ -112,6 +143,28 @@ pub fn to_sample_slice_mut<'a, T, S>(slice: T) -> &'a mut [S]
           T: ToSampleSliceMut<'a, S>,
 {
     slice.to_sample_slice_mut()
+}
+
+/// Converts the given boxed slice into a boxed slice of `Sample`s.
+///
+/// This is a convenience function that wraps the `ToBoxedSampleSlice` trait.
+///
+/// # Examples
+///
+/// ```
+/// extern crate sample;
+///
+/// fn main() {
+///     let foo = vec![[0.0, 0.5], [0.0, -0.5]].into_boxed_slice();
+///     let bar = sample::slice::to_boxed_sample_slice(foo);
+///     assert_eq!(bar.into_vec(), vec![0.0, 0.5, 0.0, -0.5]);
+/// }
+/// ```
+pub fn to_boxed_sample_slice<T, S>(slice: T) -> Box<[S]>
+    where S: Sample,
+          T: ToBoxedSampleSlice<S>,
+{
+    slice.to_boxed_sample_slice()
 }
 
 /// Converts the given slice of `Sample`s into some slice `T`.
@@ -164,6 +217,31 @@ pub fn from_sample_slice_mut<'a, T, S>(slice: &'a mut [S]) -> Option<T>
     T::from_sample_slice_mut(slice)
 }
 
+/// Converts the given boxed slice of `Sample`s into some slice `T`.
+///
+/// Returns `None` if the number of channels in a single frame is not a multiple of the number of
+/// samples in the given slice.
+///
+/// This is a convenience function that wraps the `FromBoxedSampleSlice` trait.
+///
+/// # Examples
+///
+/// ```
+/// extern crate sample;
+///
+/// fn main() {
+///     let foo = vec![0.0, 0.5, 0.0, -0.5].into_boxed_slice();
+///     let bar: Box<[[f32; 2]]> = sample::slice::from_boxed_sample_slice(foo).unwrap();
+///     assert_eq!(bar.into_vec(), vec![[0.0, 0.5], [0.0, -0.5]]);
+/// }
+/// ```
+pub fn from_boxed_sample_slice<T, S>(slice: Box<[S]>) -> Option<T>
+    where S: Sample,
+          T: FromBoxedSampleSlice<S>,
+{
+    T::from_boxed_sample_slice(slice)
+}
+
 /// Converts the given slice of `Frame`s into some slice `T`.
 ///
 /// This is a convenience function that wraps the `FromFrameSlice` trait.
@@ -206,6 +284,28 @@ pub fn from_frame_slice_mut<'a, T, F>(slice: &'a mut [F]) -> T
           T: FromFrameSliceMut<'a, F>,
 {
     T::from_frame_slice_mut(slice)
+}
+
+/// Converts the given boxed slice of `Frame`s into some slice `T`.
+///
+/// This is a convenience function that wraps the `FromBoxedFrameSlice` trait.
+///
+/// # Examples
+///
+/// ```
+/// extern crate sample;
+///
+/// fn main() {
+///     let foo = vec![[0.0, 0.5], [0.0, -0.5]].into_boxed_slice();
+///     let bar: Box<[f32]> = sample::slice::from_boxed_frame_slice(foo);
+///     assert_eq!(bar.into_vec(), vec![0.0, 0.5, 0.0, -0.5]);
+/// }
+/// ```
+pub fn from_boxed_frame_slice<T, F>(slice: Box<[F]>) -> T
+    where F: Frame,
+          T: FromBoxedFrameSlice<F>,
+{
+    T::from_boxed_frame_slice(slice)
 }
 
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,7 +1,7 @@
 //! This module provides various helper functions for performing operations on slices of frames.
 
 use {
-    Frame, Sample,
+    Box, Frame, Sample,
     ToSampleSlice, ToSampleSliceMut, ToBoxedSampleSlice,
     ToFrameSlice, ToFrameSliceMut, ToBoxedFrameSlice,
     FromSampleSlice, FromSampleSliceMut, FromBoxedSampleSlice,


### PR DESCRIPTION
This is a breaking change due to the method renaming in the `Rate` type.