### PR TITLE
Fix return type of Converter::source_mut()

### DIFF
--- a/src/rate.rs
+++ b/src/rate.rs
@@ -131,7 +131,7 @@ impl<I> Converter<I>
 
     /// Mutably borrow the `source_frames` Iterator from the `Converter`.
     #[inline]
-    pub fn source_mut(&mut self) -> &I {
+    pub fn source_mut(&mut self) -> &mut I {
         &mut self.source_frames
     }
 


### PR DESCRIPTION
I guess this was just a simple copy/paste mistake which was overlooked.