### PR TITLE
Fix out-of-bounds error when Sinc only has one sample left

### DIFF
--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -396,7 +396,7 @@ impl<F> Interpolator for Sinc<F>
     }
 
     fn is_exhausted(&self) -> bool {
-        self.frames.len() <= self.depth
+        self.frames.len() <= (self.depth + 1)
         && self.idx == self.depth
     }
 }


### PR DESCRIPTION
Every once in a while there's only one sample left. In this case, we're going to be out of bounds and should just abort.