### PR TITLE
Make `Bus` much more memory efficient

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,14 @@ extern crate alloc;
 extern crate collections;
 
 #[cfg(not(feature = "std"))]
-type Vec<T> = collections::vec::Vec<T>;
+type RandomState = collections::hash_map::RandomState;
 #[cfg(feature = "std")]
-type Vec<T> = std::vec::Vec<T>;
+type RandomState = std::collections::hash_map::RandomState;
+
+#[cfg(not(feature = "std"))]
+type HashMap<K, V, S=RandomState> = collections::hash_map::HashMap<K, V, S>;
+#[cfg(feature = "std")]
+type HashMap<K, V, S=RandomState> = std::collections::HashMap<K, V, S>;
 
 #[cfg(not(feature = "std"))]
 type VecDeque<T> = collections::vec_deque::VecDeque<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,14 +23,9 @@ extern crate alloc;
 extern crate collections;
 
 #[cfg(not(feature = "std"))]
-type RandomState = collections::hash_map::RandomState;
+type BTreeMap<K, V> = collections::btree_map::BTreeMap<K, V>;
 #[cfg(feature = "std")]
-type RandomState = std::collections::hash_map::RandomState;
-
-#[cfg(not(feature = "std"))]
-type HashMap<K, V, S=RandomState> = collections::hash_map::HashMap<K, V, S>;
-#[cfg(feature = "std")]
-type HashMap<K, V, S=RandomState> = std::collections::HashMap<K, V, S>;
+type BTreeMap<K, V> = std::collections::BTreeMap<K, V>;
 
 #[cfg(not(feature = "std"))]
 type VecDeque<T> = collections::vec_deque::VecDeque<T>;


### PR DESCRIPTION
Previously a `Bus` would require a unique `VecDeque` for keeping pending
frames for each `Output`. It also did not provide a way of removing
outputs, meaning busses with a growing number of outputs would
infinitely grow in memory usage.

This new implementation only requires a single VecDeque for pending
frames, regardless of the number of outputs. Instead, we just store a
HashMap from the output's unique key to its current index into the
pending frames buffer.

Outputs now also implement Drop and will remove themselves from the
HashMap. It will also drain the front of the buffer and
update the buffer indices for each of the outputs if the removed output
was the "latest" to receive frames.