### PR TITLE
Remove ambiguous `signal::from_slice` in favour of using `signal::from_iter`

### DIFF
--- a/examples/resample.rs
+++ b/examples/resample.rs
@@ -13,7 +13,7 @@ fn main() {
         .map(|s| [s.unwrap().to_sample()])
         .collect();
     let len = samples.len();
-    let signal = signal::from_slice(&samples[..]);
+    let signal = signal::from_iter(samples.iter().cloned());
 
     let sample_rate = reader.spec().sample_rate as f64;
     let new_sample_rate = 10_000.0;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -14,7 +14,6 @@
 //! - [gen](./fn.gen.html) for generating frames of type F from some `Fn() -> F`.
 //! - [gen_mut](./fn.gen_mut.html) for generating frames of type F from some `FnMut() -> F`.
 //! - [from_iter](./fn.from_iter.html) for converting an iterator yielding frames to a signal.
-//! - [from_slice](./fn.from_slice.html) for converting a slice of frames into a signal.
 //! - [from_interleaved_samples_iter](./fn.from_interleaved_samples_iter.html) for converting an
 //! iterator yielding interleaved samples to a signal.
 //!
@@ -45,7 +44,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.2], [-0.6], [0.4]];
-    ///     let mut signal = signal::from_slice(&frames);
+    ///     let mut signal = signal::from_iter(frames.iter().cloned());
     ///     assert_eq!(signal.next(), [0.2]);
     ///     assert_eq!(signal.next(), [-0.6]);
     ///     assert_eq!(signal.next(), [0.4]);
@@ -66,8 +65,8 @@ pub trait Signal {
     /// fn main() {
     ///     let a = [[0.2], [-0.6], [0.4]];
     ///     let b = [[0.2], [0.1], [-0.8]];
-    ///     let a_signal = signal::from_slice(&a);
-    ///     let b_signal = signal::from_slice(&b);
+    ///     let a_signal = signal::from_iter(a.iter().cloned());
+    ///     let b_signal = signal::from_iter(b.iter().cloned());
     ///     let added: Vec<_> = a_signal.add_amp(b_signal).take(3).collect();
     ///     assert_eq!(added, vec![[0.4], [-0.5], [-0.4]]);
     /// }
@@ -98,8 +97,8 @@ pub trait Signal {
     /// fn main() {
     ///     let a = [[0.25], [-0.8], [-0.5]];
     ///     let b = [[0.2], [0.5], [0.8]];
-    ///     let a_signal = signal::from_slice(&a);
-    ///     let b_signal = signal::from_slice(&b);
+    ///     let a_signal = signal::from_iter(a.iter().cloned());
+    ///     let b_signal = signal::from_iter(b.iter().cloned());
     ///     let added: Vec<_> = a_signal.mul_amp(b_signal).take(3).collect();
     ///     assert_eq!(added, vec![[0.05], [-0.4], [-0.4]]);
     /// }
@@ -129,7 +128,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.25, 0.4], [-0.2, -0.5]];
-    ///     let signal = signal::from_slice(&frames);
+    ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let offset: Vec<_> = signal.offset_amp(0.5).take(2).collect();
     ///     assert_eq!(offset, vec![[0.75, 0.9], [0.3, 0.0]]);
     /// }
@@ -157,7 +156,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.2], [-0.5], [-0.4], [0.3]];
-    ///     let signal = signal::from_slice(&frames);
+    ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let scaled: Vec<_> = signal.scale_amp(2.0).take(4).collect();
     ///     assert_eq!(scaled, vec![[0.4], [-1.0], [-0.8], [0.6]]);
     /// }
@@ -184,7 +183,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.5, 0.3], [-0.25, 0.9]];
-    ///     let signal = signal::from_slice(&frames);
+    ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let offset: Vec<_> = signal.offset_amp_per_channel([0.25, -0.5]).take(2).collect();
     ///     assert_eq!(offset, vec![[0.75, -0.2], [0.0, 0.4]]);
     /// }
@@ -213,7 +212,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.2, -0.5], [-0.4, 0.3]];
-    ///     let signal = signal::from_slice(&frames);
+    ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let scaled: Vec<_> = signal.scale_amp_per_channel([0.5, 2.0]).take(2).collect();
     ///     assert_eq!(scaled, vec![[0.1, -1.0], [-0.2, 0.6]]);
     /// }
@@ -246,9 +245,10 @@ pub trait Signal {
     /// fn main() {
     ///     let foo = [[0.0], [1.0], [0.0], [-1.0]];
     ///     let mul = [[1.0], [1.0], [0.5], [0.5], [0.5], [0.5]];
-    ///     let mut source = signal::from_slice(&foo);
+    ///     let mut source = signal::from_iter(foo.iter().cloned());
     ///     let interp = Linear::from_source(&mut source);
-    ///     let frames: Vec<_> = source.mul_hz(interp, signal::from_slice(&mul)).take(6).collect();
+    ///     let hz_signal = signal::from_iter(mul.iter().cloned());
+    ///     let frames: Vec<_> = source.mul_hz(interp, hz_signal).take(6).collect();
     ///     assert_eq!(&frames[..], &[[0.0], [1.0], [0.0], [-0.5], [-1.0], [-0.5]][..]);
     /// }
     /// ```
@@ -275,7 +275,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let foo = [[0.0], [1.0], [0.0], [-1.0]];
-    ///     let mut source = signal::from_slice(&foo);
+    ///     let mut source = signal::from_iter(foo.iter().cloned());
     ///     let interp = Linear::from_source(&mut source);
     ///     let frames: Vec<_> = source.from_hz_to_hz(interp, 1.0, 2.0).take(8).collect();
     ///     assert_eq!(&frames[..], &[[0.0], [0.5], [1.0], [0.5], [0.0], [-0.5], [-1.0], [-0.5]][..]);
@@ -300,7 +300,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let foo = [[0.0], [1.0], [0.0], [-1.0]];
-    ///     let mut source = signal::from_slice(&foo);
+    ///     let mut source = signal::from_iter(foo.iter().cloned());
     ///     let interp = Linear::from_source(&mut source);
     ///     let frames: Vec<_> = source.scale_hz(interp, 0.5).take(8).collect();
     ///     assert_eq!(&frames[..], &[[0.0], [0.5], [1.0], [0.5], [0.0], [-0.5], [-1.0], [-0.5]][..]);
@@ -327,7 +327,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.2], [0.4]];
-    ///     let signal = signal::from_slice(&frames);
+    ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let delayed: Vec<_> = signal.delay(2).take(4).collect();
     ///     assert_eq!(delayed, vec![[0.0], [0.0], [0.2], [0.4]]);
     /// }
@@ -380,7 +380,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[1.2, 0.8], [-0.7, -1.4]];
-    ///     let signal = signal::from_slice(&frames);
+    ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let clipped: Vec<_> = signal.clip_amp(0.9).take(2).collect();
     ///     assert_eq!(clipped, vec![[0.9, 0.8], [-0.7, -0.9]]);
     /// }
@@ -415,7 +415,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.1], [0.2], [0.3], [0.4], [0.5], [0.6]];
-    ///     let signal = signal::from_slice(&frames);
+    ///     let signal = signal::from_iter(frames.iter().cloned());
     ///     let bus = signal.bus();
     ///     let mut a = bus.send();
     ///     let mut b = bus.send();
@@ -446,7 +446,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0.1], [0.2], [0.3], [0.4]];
-    ///     let mut signal = signal::from_slice(&frames).take(2);
+    ///     let mut signal = signal::from_iter(frames.iter().cloned()).take(2);
     ///     assert_eq!(signal.next(), Some([0.1]));
     ///     assert_eq!(signal.next(), Some([0.2]));
     ///     assert_eq!(signal.next(), None);
@@ -475,7 +475,7 @@ pub trait Signal {
     ///
     /// fn main() {
     ///     let frames = [[0], [1], [2], [3], [4]];
-    ///     let mut signal = signal::from_slice(&frames);
+    ///     let mut signal = signal::from_iter(frames.iter().cloned());
     ///     assert_eq!(signal.next(), [0]);
     ///     assert_eq!(signal.by_ref().take(2).collect::<Vec<_>>(), vec![[1], [2]]);
     ///     assert_eq!(signal.next(), [3]);
@@ -849,36 +849,6 @@ pub fn from_iter<I>(frames: I) -> FromIterator<I::IntoIter>
 {
     FromIterator {
         iter: frames.into_iter(),
-    }
-}
-
-
-/// Create a new `Signal` from the given slice of `Frame`s.
-///
-/// When the given slice is exhausted, the new `Signal` will yield `F::equilibrium`.
-///
-/// # Example
-///
-/// ```rust
-/// extern crate sample;
-///
-/// use sample::{signal, Signal};
-///
-/// fn main() {
-///     let frames = [[1], [-3], [5], [6]];
-///     let mut signal = signal::from_slice(&frames);
-///     assert_eq!(signal.next(), [1]);
-///     assert_eq!(signal.next(), [-3]);
-///     assert_eq!(signal.next(), [5]);
-///     assert_eq!(signal.next(), [6]);
-///     assert_eq!(signal.next(), [0]);
-/// }
-/// ```
-pub fn from_slice<F>(frames: &[F]) -> FromIterator<core::iter::Cloned<core::slice::Iter<F>>>
-    where F: Frame,
-{
-    FromIterator {
-        iter: frames.iter().cloned(),
     }
 }
 
@@ -1802,7 +1772,7 @@ impl<S> Output<S>
     ///
     /// fn main() {
     ///     let frames = [[0.1], [0.2], [0.3]];
-    ///     let bus = signal::from_slice(&frames).bus();
+    ///     let bus = signal::from_iter(frames.iter().cloned()).bus();
     ///     let signal = bus.send();
     ///     let mut monitor = bus.send();
     ///     assert_eq!(signal.take(3).collect::<Vec<_>>(), vec![[0.1], [0.2], [0.3]]);

--- a/src/window.rs
+++ b/src/window.rs
@@ -158,7 +158,7 @@ impl<'a, F, W> Iterator for Windower<'a, F, W>
             let window = Window::new(self.bin);
             self.frames = if self.hop < num_frames { &self.frames[self.hop..] } else { &[] };
             Some(Windowed {
-                signal: signal::from_slice(frames),
+                signal: signal::from_iter(frames.iter().cloned()),
                 window: window,
             })
         } else {

--- a/tests/interpolate.rs
+++ b/tests/interpolate.rs
@@ -8,7 +8,7 @@ use sample::{signal, Signal};
 #[test]
 fn test_floor_converter() {
     let frames: [[f64; 1]; 3] = [[0.0], [1.0], [2.0]];
-    let mut source = signal::from_slice(&frames);
+    let mut source = signal::from_iter(frames.iter().cloned());
     let interp = Floor::from_source(&mut source);
     let mut conv = Converter::scale_playback_hz(source, interp, 0.5);
 
@@ -27,7 +27,7 @@ fn test_floor_converter() {
 #[test]
 fn test_linear_converter() {
     let frames: [[f64; 1]; 3] = [[0.0], [1.0], [2.0]];
-    let mut source = signal::from_slice(&frames);
+    let mut source = signal::from_iter(frames.iter().cloned());
     let interp = Linear::from_source(&mut source);
     let mut conv = Converter::scale_playback_hz(source, interp, 0.5);
 
@@ -45,7 +45,7 @@ fn test_linear_converter() {
 fn test_scale_playback_rate() {
     // Scale the playback rate by `0.5`
     let foo = [[0.0], [1.0], [0.0], [-1.0]];
-    let mut source = signal::from_slice(&foo);
+    let mut source = signal::from_iter(foo.iter().cloned());
     let interp = Linear::from_source(&mut source);
     let frames: Vec<_> = source.scale_hz(interp, 0.5).take(8).collect();
     assert_eq!(&frames[..], &[[0.0], [0.5], [1.0], [0.5], [0.0], [-0.5], [-1.0], [-0.5]][..]);

--- a/tests/signal.rs
+++ b/tests/signal.rs
@@ -14,7 +14,10 @@ fn test_equilibrium() {
 fn test_scale_amp() {
     let foo = [[0.5], [0.8], [-0.4], [-0.2]];
     let amp = 0.5;
-    let amp_scaled: Vec<_> = signal::from_slice(&foo).scale_amp(amp).take(4).collect();
+    let amp_scaled: Vec<_> = signal::from_iter(foo.iter().cloned())
+        .scale_amp(amp)
+        .take(4)
+        .collect();
     assert_eq!(amp_scaled, vec![[0.25], [0.4], [-0.2], [-0.1]]);
 }
 
@@ -22,6 +25,9 @@ fn test_scale_amp() {
 fn test_offset_amp() {
     let foo = [[0.5], [0.9], [-0.4], [-0.2]];
     let amp = -0.5;
-    let amp_offset: Vec<_> = signal::from_slice(&foo).offset_amp(amp).take(4).collect();
+    let amp_offset: Vec<_> = signal::from_iter(foo.iter().cloned())
+        .offset_amp(amp)
+        .take(4)
+        .collect();
     assert_eq!(amp_offset, vec![[0.0], [0.4], [-0.9], [-0.7]]);
 }


### PR DESCRIPTION
As mentioned in #57 within [this comment](https://github.com/RustAudio/sample/pull/57#issuecomment-315672158).

cc @andrewcsmith 