### PR TITLE
Add signal::tap functionality

### DIFF
--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1778,7 +1778,7 @@ impl<S> Signal for ClipAmp<S>
 impl<S> Bus<S>
     where S: Signal,
 {
-    fn new(signal: S, frames_read: BTreeMap<usize, usize>) -> Self {
+    pub fn new(signal: S, frames_read: BTreeMap<usize, usize>) -> Self {
         Bus {
             node: Rc::new(core::cell::RefCell::new(SharedNode {
                 signal: signal,

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -482,7 +482,9 @@ pub trait Signal {
     ///     assert_eq!(signal.next(), [4]);
     /// }
     /// ```
-    fn by_ref(&mut self) -> &mut Self {
+    fn by_ref(&mut self) -> &mut Self
+        where Self: Sized
+    {
         self
     }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1139,6 +1139,16 @@ pub fn noise_simplex<S>(phase: Phase<S>) -> NoiseSimplex<S> {
 
 //// Trait Implementations for Signal Types.
 
+impl<F> Signal for Box<Signal<Frame=F>> 
+    where F: Frame
+{
+    type Frame = F;
+    #[inline]
+    fn next(&mut self) -> Self::Frame {
+        use core::ops::DerefMut;
+        self.deref_mut().next()
+    }
+}
 
 impl<I> Signal for FromIterator<I>
     where I: Iterator,


### PR DESCRIPTION
Allows the caller to tap into method chain. Useful for non-linear signal flow, scoping, and other tools.

This is becoming a fairly critical part of a new project that requires scope analysis at various parts of the method chain. The advantage to using `tap` is that the entire signal chain doesn't have to be broken up by temporary variables.