### PR TITLE
Move signal `map` and `zip_map` functions to `Signal` trait methods. Publish 0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,7 @@
 [package]
-
 name = "sample"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.6.2"
+version = "0.7.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]


### PR DESCRIPTION
cc @andrewcsmith thanks so much for all these PRs btw, it's a massive help!

- Signal Map and ZipMap #68
- impl Signal for Box<Signal> #67
- Change Signal::next return type from Option<Frame> to Frame #57
- Make `Bus` more memory efficient #58