### PR TITLE
Implement Signal for unsized types implementing Signal (trait objs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.7.0"
+version = "0.7.1"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -585,7 +585,7 @@ pub trait Signal {
 
 
 impl<'a, S> Signal for &'a mut S
-    where S: Signal,
+    where S: Signal + ?Sized,
 {
     type Frame = S::Frame;
     fn next(&mut self) -> Self::Frame {
@@ -1164,14 +1164,13 @@ pub fn noise_simplex<S>(phase: Phase<S>) -> NoiseSimplex<S> {
 
 //// Trait Implementations for Signal Types.
 
-impl<F> Signal for Box<Signal<Frame=F>> 
-    where F: Frame
+impl<S> Signal for Box<S>
+    where S: Signal + ?Sized,
 {
-    type Frame = F;
+    type Frame = S::Frame;
     #[inline]
     fn next(&mut self) -> Self::Frame {
-        use core::ops::DerefMut;
-        self.deref_mut().next()
+        (**self).next()
     }
 }
 


### PR DESCRIPTION
This extends the existing implementation for `&'a mut S where S: Signal`
and `Box<Signal>` to be a little more general.

E.g.

`&mut my_signal as &mut Signal`

now produces a `&mut Signal` trait object which also implements
`Signal`.

Boxed signals no longer require the `Sized` bound in order to implement
`Signal` themselves, E.g. the `Sized` bound in

`Box<Signal<Frame=[f32; 2]> + Sized>`

is no longer necessary.

These changes now reflect the implementations of `Iterator` for `&mut
Iterator` and `Box<Iterator>` in the std library.

cc @andrewcsmith this alters the `Signal` impl for `Box<Signal>`
introduced in #66, however I don't believe this is a breaking change as
it should be strictly more general :+1: