### PR TITLE
Clarifications in documentation about sample conversions

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -9,6 +9,9 @@
 //!
 //! The conversion functions do *not* check the range of incoming values for floating point values
 //! or any of the custom `I24`, `U24`, `I48` and `U48` types.
+//!
+//! Note that floating point conversions use the range -1.0 <= v < 1.0:
+//! `(1.0 as f64).to_sample::<i16>()` will overflow!
 
 use {Box, Frame, Sample};
 use core;
@@ -531,7 +534,7 @@ conversions!(u64, u64 {
     s to_f64 { super::i64::to_f64(to_i64(s)) }
 });
 
-// The following conversions assume `-1.0 <= s < 1.0` and will overflow otherwise.
+// The following conversions assume `-1.0 <= s < 1.0` (note that +1.0 is excluded) and will overflow otherwise.
 conversions!(f32, f32 {
     s to_i8 { (s * 128.0) as i8 }
     s to_i16 { (s * 32_768.0) as i16 }
@@ -548,7 +551,7 @@ conversions!(f32, f32 {
     s to_f64 { s as f64 }
 });
 
-// The following conversions assume `-1.0 <= s < 1.0` and will overflow otherwise.
+// The following conversions assume `-1.0 <= s < 1.0` (note that +1.0 is excluded) and will overflow otherwise.
 conversions!(f64, f64 {
     s to_i8 { (s * 128.0) as i8 }
     s to_i16 { (s * 32_768.0) as i16 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,6 +237,8 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
     }
 
     /// Convert `self` to any type that implements `FromSample<Self>`.
+	///
+	/// (See the caveats in the `conv` module.)
     ///
     /// # Example
     ///
@@ -259,6 +261,8 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
     }
 
     /// Create a `Self` from any type that implements `ToSample<Self>`.
+	///
+	/// (See the caveats in the `conv` module.)
     ///
     /// # Example
     ///


### PR DESCRIPTION
- Mentioned that the `conv` module gives details in `Sample::to_sample()` and `Sample::from_sample().
- Noted the floating point conversion quirk in the documentation for `conv` as it already lists caveats.
- Clarified comments in `conv` because the `-1.0 <= s < 1.0` is easy to misread as `-1.0 <= s <= 1.0`.

Hopefully this is sufficient to close issue #73.