### PR TITLE
 Publish 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.7.1"
+version = "0.8.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -534,7 +534,8 @@ conversions!(u64, u64 {
     s to_f64 { super::i64::to_f64(to_i64(s)) }
 });
 
-// The following conversions assume `-1.0 <= s < 1.0` (note that +1.0 is excluded) and will overflow otherwise.
+// The following conversions assume `-1.0 <= s < 1.0` (note that +1.0 is excluded) and will
+// overflow otherwise.
 conversions!(f32, f32 {
     s to_i8 { (s * 128.0) as i8 }
     s to_i16 { (s * 32_768.0) as i16 }
@@ -551,7 +552,8 @@ conversions!(f32, f32 {
     s to_f64 { s as f64 }
 });
 
-// The following conversions assume `-1.0 <= s < 1.0` (note that +1.0 is excluded) and will overflow otherwise.
+// The following conversions assume `-1.0 <= s < 1.0` (note that +1.0 is excluded) and will
+// overflow otherwise.
 conversions!(f64, f64 {
     s to_i8 { (s * 128.0) as i8 }
     s to_i16 { (s * 32_768.0) as i16 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,8 +237,8 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
     }
 
     /// Convert `self` to any type that implements `FromSample<Self>`.
-	///
-	/// (See the caveats in the `conv` module.)
+    ///
+    /// Find more details on type-specific conversion ranges and caveats in the `conv` module.
     ///
     /// # Example
     ///
@@ -261,8 +261,8 @@ pub trait Sample: Copy + Clone + PartialOrd + PartialEq {
     }
 
     /// Create a `Self` from any type that implements `ToSample<Self>`.
-	///
-	/// (See the caveats in the `conv` module.)
+    ///
+    /// Find more details on type-specific conversion ranges and caveats in the `conv` module.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Non-breaking:

- Adds a new `ring_buffer` module.
- Adds a `Signal::buffered` adaptor.

Breaking:

- Changes the `Sinc` interpolator to use `ring_buffer::Fixed`.