### PR TITLE
Add `rms` module with `Rms` type that uses `Fixed` ring buffer as window

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,30 +52,35 @@ assert_eq!(bar, [128u8, 128]);
 
 Use the **Signal** trait for working with infinite-iterator-like types that
 yield `Frame`s. **Signal** provides methods for adding, scaling, offsetting,
-multiplying, clipping and generating streams of `Frame`s. Working with
-**Signal**s allows for easy, readable creation of rich and complex DSP graphs
-with a simple and familiar API.
+multiplying, clipping, generating, monitoring and buffering streams of `Frame`s.
+Working with **Signal**s allows for easy, readable creation of rich and complex
+DSP graphs with a simple and familiar API.
 
 ```rust
 // Clip to an amplitude of 0.9.
 let frames = [[1.2, 0.8], [-0.7, -1.4]];
-let clipped: Vec<_> = signal::from_slice(&frames).clip_amp(0.9).take(2).collect();
+let clipped: Vec<_> = signal::from_iter(frames.iter().cloned()).clip_amp(0.9).take(2).collect();
 assert_eq!(clipped, vec![[0.9, 0.8], [-0.7, -0.9]]);
 
 // Add `a` with `b` and yield the result.
 let a = [[0.2], [-0.6], [0.5]];
 let b = [[0.2], [0.1], [-0.8]];
-let a_signal = signal::from_slice(&a);
-let b_signal = signal::from_slice(&b);
+let a_signal = signal::from_iter(a.iter().cloned());
+let b_signal = signal::from_iter(b.iter().cloned());
 let added: Vec<[f32; 1]> = a_signal.add_amp(b_signal).take(3).collect();
 assert_eq!(added, vec![[0.4], [-0.5], [-0.3]]);
 
 // Scale the playback rate by `0.5`.
 let foo = [[0.0], [1.0], [0.0], [-1.0]];
-let mut source = signal::from_slice(&foo);
+let mut source = signal::from_iter(foo.iter().cloned());
 let interp = Linear::from_source(&mut source);
 let frames: Vec<_> = source.scale_hz(interp, 0.5).take(8).collect();
 assert_eq!(&frames[..], &[[0.0], [0.5], [1.0], [0.5], [0.0], [-0.5], [-1.0], [-0.5]][..]);
+
+// Convert a signal to its RMS.
+let signal = signal::rate(44_100.0).const_hz(440.0).sine();;
+let ring_buffer = ring_buffer::Fixed::from([[0.0]; WINDOW_SIZE]);
+let mut rms_signal = signal.rms(ring_buffer);
 ```
 
 The **signal** module also provides a series of **Signal** source types,
@@ -137,6 +142,11 @@ allocated buffers.
 The **peak** module can be used for monitoring the peak of a signal. Provided
 peak rectifiers include `full_wave`, `positive_half_wave` and
 `negative_half_wave`.
+
+The **rms** module provides a flexible **Rms** type that can be used for RMS
+(root mean square) detection. Any **Fixed** ring buffer can be used as the
+window for the RMS detection.
+
 
 Using in a `no_std` environment
 -------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod conv;
 pub mod frame;
 pub mod peak;
 pub mod ring_buffer;
+pub mod rms;
 pub mod signal;
 pub mod types;
 pub mod window;

--- a/src/rms.rs
+++ b/src/rms.rs
@@ -1,0 +1,134 @@
+//! Root mean square calculation over a signal.
+//!
+//! The primary type of interest in this module is the [**Rms**](./struct.Rms).
+
+use {FloatSample, Frame, Sample};
+use core::fmt;
+use core::marker::PhantomData;
+use ring_buffer;
+
+/// Iteratively extracts the RMS (root mean square) envelope from a window over a signal of sample
+/// `Frame`s.
+#[derive(Clone)]
+pub struct Rms<F, S>
+where
+    F: Frame,
+    S: ring_buffer::Slice<Element = F::Float>,
+{
+    /// The type of `Frame`s for which the RMS will be calculated.
+    frame: PhantomData<F>,
+    /// The ringbuffer of frame sample squares (i.e. `sample * sample`) used to calculate the RMS
+    /// per frame.
+    ///
+    /// When a new frame is received, the **Rms** pops the front sample_square and adds the new
+    /// sample_square to the back.
+    window: ring_buffer::Fixed<S>,
+    /// The sum total of all sample_squares currently within the **Rms**'s `window` ring buffer.
+    square_sum: F::Float,
+}
+
+impl<F, S> Rms<F, S>
+where
+    F: Frame,
+    S: ring_buffer::Slice<Element = F::Float>,
+{
+    /// Construct a new **Rms** that uses the given ring buffer as its window.
+    ///
+    /// The window size of the **Rms** is equal to the length of the given ring buffer.
+    pub fn new(ring_buffer: ring_buffer::Fixed<S>) -> Self {
+        Rms {
+            frame: PhantomData,
+            window: ring_buffer,
+            square_sum: Frame::equilibrium(),
+        }
+    }
+
+    /// Zeroes the square_sum and the buffer of the `window`.
+    pub fn reset(&mut self)
+    where
+        S: ring_buffer::SliceMut,
+    {
+        for sample_square in self.window.iter_mut() {
+            *sample_square = Frame::equilibrium();
+        }
+        self.square_sum = Frame::equilibrium();
+    }
+
+    /// The length of the window as a number of frames.
+    #[inline]
+    pub fn window_frames(&self) -> usize {
+        self.window.len()
+    }
+
+    /// The next RMS given the new frame in the sequence.
+    ///
+    /// The **Rms** pops its front frame and adds the new frame to the back.
+    ///
+    /// The yielded RMS is the RMS of all frame squares in the `window` after the new frame is
+    /// added.
+    ///
+    /// This method uses `Rms::next_squared` internally and then calculates the square root.
+    #[inline]
+    pub fn next(&mut self, new_frame: F) -> F::Float
+    where
+        S: ring_buffer::SliceMut,
+    {
+        self.next_squared(new_frame).map(|s| s.sample_sqrt())
+    }
+
+    /// The same as **Rms::next**, but does not calculate the final square root required to
+    /// determine the RMS.
+    #[inline]
+    pub fn next_squared(&mut self, new_frame: F) -> F::Float
+    where
+        S: ring_buffer::SliceMut,
+    {
+        // Determine the square of the new frame.
+        let new_frame_square = new_frame.to_float_frame().map(|s| s * s);
+        // Push back the new frame_square.
+        let removed_frame_square = self.window.push(new_frame_square);
+        // Add the new frame square and subtract the removed frame square.
+        self.square_sum = self.square_sum.add_amp(new_frame_square).zip_map(
+            removed_frame_square,
+            |s, r| {
+                let diff = s - r;
+                // Don't let floating point rounding errors put us below 0.0.
+                if diff < Sample::equilibrium() {
+                    Sample::equilibrium()
+                } else {
+                    diff
+                }
+            },
+        );
+        self.calc_rms_squared()
+    }
+
+    /// Consumes the **Rms** and returns its inner ring buffer of squared frames along with a frame
+    /// representing the sum of all frame squares contained within the ring buffer.
+    pub fn into_parts(self) -> (ring_buffer::Fixed<S>, S::Element) {
+        let Rms { window, square_sum, .. } = self;
+        (window, square_sum)
+    }
+
+    fn calc_rms_squared(&self) -> F::Float {
+        let num_frames_f = Sample::from_sample(self.window.len() as f32);
+        self.square_sum.map(|s| s / num_frames_f)
+    }
+}
+
+impl<F, S> fmt::Debug for Rms<F, S>
+where
+    F: Frame,
+    F::Float: fmt::Debug,
+    S: fmt::Debug + ring_buffer::Slice<Element = F::Float>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "Rms {{ frame: {:?}, window: {:?}, square_sum: {:?} }}",
+            &self.frame,
+            &self.window,
+            &self.square_sum
+        )
+    }
+}

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -24,6 +24,7 @@ use {BTreeMap, Duplex, Frame, Sample, Rc, VecDeque, Box};
 use core;
 use interpolate::{Converter, Interpolator};
 use ring_buffer;
+use rms;
 
 
 /// Types that yield `Frame`s as a multi-channel PCM signal.
@@ -651,6 +652,38 @@ pub trait Signal {
         }
     }
 
+    /// An adaptor that yields the RMS of the signal.
+    ///
+    /// The window size of the RMS detector is equal to the given ring buffer length.
+    ///
+    /// ```
+    /// extern crate sample;
+    ///
+    /// use sample::ring_buffer;
+    /// use sample::{signal, Signal};
+    ///
+    /// fn main() {
+    ///     let frames = [[0.9], [-0.8], [0.6], [-0.9]];
+    ///     let signal = signal::from_iter(frames.iter().cloned());
+    ///     let ring_buffer = ring_buffer::Fixed::from([[0.0]; 2]);
+    ///     let mut rms_signal = signal.rms(ring_buffer);
+    ///     assert_eq!(
+    ///         [rms_signal.next(), rms_signal.next(), rms_signal.next()],
+    ///         [[0.6363961030678927], [0.8514693182963201], [0.7071067811865476]]
+    ///     );
+    /// }
+    /// ```
+    fn rms<S>(self, ring_buffer: ring_buffer::Fixed<S>) -> Rms<Self, S>
+    where
+        Self: Sized,
+        S: ring_buffer::Slice<Element = <Self::Frame as Frame>::Float> + ring_buffer::SliceMut,
+    {
+        Rms {
+            signal: self,
+            rms: rms::Rms::new(ring_buffer),
+        }
+    }
+
     /// Borrows a Signal rather than consuming it.
     ///
     /// This is useful to allow applying signal adaptors while still retaining ownership of the
@@ -983,6 +1016,19 @@ pub struct Buffered<S, D> {
 /// Returns `None` once the inner ring buffer is exhausted.
 pub struct BufferedFrames<'a, D: 'a> {
     ring_buffer: &'a mut ring_buffer::Bounded<D>,
+}
+
+/// An adaptor that yields the RMS of the signal.
+///
+/// The window size of the RMS detector is equal to the given ring buffer length.
+#[derive(Clone)]
+pub struct Rms<S, D>
+where
+    S: Signal,
+    D: ring_buffer::Slice<Element = <S::Frame as Frame>::Float>,
+{
+    signal: S,
+    rms: rms::Rms<S::Frame, D>,
 }
 
 
@@ -2474,8 +2520,9 @@ where
 }
 
 impl<S, D> Signal for Buffered<S, D>
-    where S: Signal,
-          D: ring_buffer::Slice<Element=S::Frame> + ring_buffer::SliceMut,
+where
+    S: Signal,
+    D: ring_buffer::Slice<Element=S::Frame> + ring_buffer::SliceMut,
 {
     type Frame = S::Frame;
     fn next(&mut self) -> Self::Frame {
@@ -2499,5 +2546,38 @@ where
     type Item = D::Element;
     fn next(&mut self) -> Option<Self::Item> {
         self.ring_buffer.pop()
+    }
+}
+
+impl<S, D> Rms<S, D>
+where
+    S: Signal,
+    D: ring_buffer::Slice<Element = <S::Frame as Frame>::Float> + ring_buffer::SliceMut,
+{
+/// The same as `Signal::next` but does not calculate the final square root required to
+/// determine the RMS.
+    pub fn next_squared(&mut self) -> <Self as Signal>::Frame {
+        self.rms.next_squared(self.signal.next())
+    }
+
+/// Consumes the `Rms` signal and returns its inner signal `S` and `Rms` detector.
+    pub fn into_parts(self) -> (S, rms::Rms<S::Frame, D>) {
+        let Rms {
+            signal,
+            rms,
+        } = self;
+        (signal, rms)
+    }
+}
+
+impl<S, D> Signal for Rms<S, D>
+where
+    S: Signal,
+    D: ring_buffer::Slice<Element = <S::Frame as Frame>::Float>
+        + ring_buffer::SliceMut,
+{
+    type Frame = <S::Frame as Frame>::Float;
+    fn next(&mut self) -> Self::Frame {
+        self.rms.next(self.signal.next())
     }
 }


### PR DESCRIPTION
The window size used for calculating RMS is equivalent to the length of
the `Fixed` ring buffer used to construct the `Rms`.

Also includes a `Signal::rms` method for producing a `signal::Rms` adaptor.

cc @andrewcsmith what are your thoughts on adding this? I figure working
with RMS is common enough to justify adding this?