### PR TITLE
Add a peak module with full-wave and half-wave rectifier functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ The **ring_buffer** module provides generic **Fixed** and **Bounded** ring
 buffer types, both of which may be used with owned, borrowed, stack and
 allocated buffers.
 
+The **peak** module can be used for monitoring the peak of a signal. Provided
+peak rectifiers include `full_wave`, `positive_half_wave` and
+`negative_half_wave`.
 
 Using in a `no_std` environment
 -------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub use types::{I24, U24, I48, U48};
 pub mod slice;
 pub mod conv;
 pub mod frame;
+pub mod peak;
 pub mod ring_buffer;
 pub mod signal;
 pub mod types;

--- a/src/peak.rs
+++ b/src/peak.rs
@@ -1,0 +1,42 @@
+//! Peak envelope detection over a signal.
+
+use {Frame, Sample};
+
+/// A signal rectifier that produces only the positive samples.
+pub fn positive_half_wave<F>(frame: F) -> F
+where
+    F: Frame,
+{
+    frame.map(|s| if s < Sample::equilibrium() {
+        Sample::equilibrium()
+    } else {
+        s
+    })
+}
+
+/// A signal rectifier that produces only the negative samples.
+pub fn negative_half_wave<F>(frame: F) -> F
+where
+    F: Frame,
+{
+    frame.map(|s| if s > Sample::equilibrium() {
+        Sample::equilibrium()
+    } else {
+        s
+    })
+}
+
+/// A signal rectifier that produces the absolute amplitude from samples.
+pub fn full_wave<F>(frame: F) -> F
+where
+    F: Frame,
+{
+    frame.map(|s| {
+        let signed = s.to_signed_sample();
+        if signed < Sample::equilibrium() {
+            -signed
+        } else {
+            signed
+        }.to_sample()
+    })
+}

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -53,7 +53,7 @@ pub trait Signal {
     /// ```
     fn next(&mut self) -> Self::Frame;
 
-    /// A signal that maps one set of frames to another
+    /// A signal that maps one set of frames to another.
     ///
     /// # Example
     ///
@@ -68,6 +68,25 @@ pub trait Signal {
     ///     assert_eq!(mapper.next(), [0.5, 0.25]);
     ///     assert_eq!(mapper.next(), [0.5, 0.25]);
     ///     assert_eq!(mapper.next(), [0.5, 0.25]);
+    /// }
+    /// ```
+    ///
+    /// This can also be useful for monitoring the peak values of a signal.
+    ///
+    /// ```
+    /// extern crate sample;
+    ///
+    /// use sample::{peak, signal, Frame, Signal};
+    ///
+    /// fn main() {
+    ///     let sine_wave = signal::rate(4.0).const_hz(1.0).sine();
+    ///     let mut peak = sine_wave
+    ///         .map(peak::full_wave)
+    ///         .map(|f| [f[0].round()]);
+    ///     assert_eq!(
+    ///         peak.take(4).collect::<Vec<_>>(),
+    ///         vec![[0.0], [1.0], [0.0], [1.0]]
+    ///     );
     /// }
     /// ```
     fn map<M, F>(self, map: M) -> Map<Self, M, F>


### PR DESCRIPTION
Also adds an example of usage with a signal to the Signal::map method
documentation.