### PR TITLE
 Add new `envelope` module along with an `envelope::Detector` type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ The **rms** module provides a flexible **Rms** type that can be used for RMS
 (root mean square) detection. Any **Fixed** ring buffer can be used as the
 window for the RMS detection.
 
+The **envelope** module provides a **Detector** type (also known as a
+*Follower*) that allows for detecting the envelope of a signal. **Detector** is
+generic over the type of **Detect**ion - **Rms** and **Peak** detection are
+provided. For example:
+
+```rust
+let signal = signal::rate(4.0).const_hz(1.0).sine();
+let attack = 1.0;
+let release = 1.0;
+let detector = envelope::Detector::peak(attack, release);
+let mut envelope = signal.detect_envelope(detector);
+assert_eq!(
+    envelope.take(4).collect::<Vec<_>>(),
+    vec![[0.0], [0.6321205496788025], [0.23254416035257117], [0.7176687675647109]]
+);
+```
+
 
 Using in a `no_std` environment
 -------------------------------

--- a/src/envelope/detect.rs
+++ b/src/envelope/detect.rs
@@ -23,7 +23,7 @@ where
     F: Frame,
 {
     /// The result of detection.
-    type Output: Frame<NumChannels=F::NumChannels>;
+    type Output: Frame<NumChannels = F::NumChannels>;
     /// Given some frame, return the detected envelope over each channel.
     fn detect(&mut self, frame: F) -> Self::Output;
 }
@@ -31,7 +31,7 @@ where
 /// A `Peak` detector, generic over the `FullWave`, `PositiveHalfWave`, `NegativeHalfWave`
 /// rectifiers.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct Peak<R=peak::FullWave> {
+pub struct Peak<R = peak::FullWave> {
     rectifier: R,
 }
 
@@ -86,7 +86,7 @@ where
 }
 
 fn calc_gain(n_frames: f32) -> f32 {
-    core::f32::consts::E.powf(-1.0 / n_frames)
+    ::ops::f32::powf32(core::f32::consts::E, -1.0 / n_frames)
 }
 
 impl<F, S> Detector<F, rms::Rms<F, S>>
@@ -94,7 +94,7 @@ where
     F: Frame,
     S: ring_buffer::Slice<Element = F::Float> + ring_buffer::SliceMut,
 {
-    /// Construct a new **Rms** **Detector**.
+/// Construct a new **Rms** **Detector**.
     pub fn rms(buffer: ring_buffer::Fixed<S>, attack_frames: f32, release_frames: f32) -> Self {
         let rms = rms::Rms::new(buffer);
         Self::new(rms, attack_frames, release_frames)

--- a/src/envelope/detect.rs
+++ b/src/envelope/detect.rs
@@ -1,0 +1,191 @@
+use {Frame, Sample};
+use core;
+use peak;
+use ring_buffer;
+use rms;
+
+/// A type that can be used to detect the envelope of a signal.
+#[derive(Clone, Debug)]
+pub struct Detector<F, D>
+where
+    F: Frame,
+    D: Detect<F>,
+{
+    last_env_frame: D::Output,
+    attack_gain: f32,
+    release_gain: f32,
+    detect: D,
+}
+
+/// Types that may be used to detect an envelope over a signal.
+pub trait Detect<F>
+where
+    F: Frame,
+{
+    /// The result of detection.
+    type Output: Frame<NumChannels=F::NumChannels>;
+    /// Given some frame, return the detected envelope over each channel.
+    fn detect(&mut self, frame: F) -> Self::Output;
+}
+
+/// A `Peak` detector, generic over the `FullWave`, `PositiveHalfWave`, `NegativeHalfWave`
+/// rectifiers.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Peak<R=peak::FullWave> {
+    rectifier: R,
+}
+
+impl<R> From<R> for Peak<R> {
+    fn from(rectifier: R) -> Self {
+        Peak { rectifier: rectifier }
+    }
+}
+
+impl Peak<peak::FullWave> {
+    /// A signal rectifier that produces the absolute amplitude from samples.
+    pub fn full_wave() -> Self {
+        peak::FullWave.into()
+    }
+}
+
+impl Peak<peak::PositiveHalfWave> {
+    /// A signal rectifier that produces only the positive samples.
+    pub fn positive_half_wave() -> Self {
+        peak::PositiveHalfWave.into()
+    }
+}
+
+impl Peak<peak::NegativeHalfWave> {
+    /// A signal rectifier that produces only the negative samples.
+    pub fn negative_half_wave() -> Self {
+        peak::NegativeHalfWave.into()
+    }
+}
+
+impl<F, R> Detect<F> for Peak<R>
+where
+    F: Frame,
+    R: peak::Rectifier<F>,
+{
+    type Output = R::Output;
+    fn detect(&mut self, frame: F) -> Self::Output {
+        self.rectifier.rectify(frame)
+    }
+}
+
+impl<F, S> Detect<F> for rms::Rms<F, S>
+where
+    F: Frame,
+    S: ring_buffer::Slice<Element = F::Float>
+        + ring_buffer::SliceMut,
+{
+    type Output = F::Float;
+    fn detect(&mut self, frame: F) -> Self::Output {
+        self.next(frame)
+    }
+}
+
+fn calc_gain(n_frames: f32) -> f32 {
+    core::f32::consts::E.powf(-1.0 / n_frames)
+}
+
+impl<F, S> Detector<F, rms::Rms<F, S>>
+where
+    F: Frame,
+    S: ring_buffer::Slice<Element = F::Float> + ring_buffer::SliceMut,
+{
+    /// Construct a new **Rms** **Detector**.
+    pub fn rms(buffer: ring_buffer::Fixed<S>, attack_frames: f32, release_frames: f32) -> Self {
+        let rms = rms::Rms::new(buffer);
+        Self::new(rms, attack_frames, release_frames)
+    }
+}
+
+impl<F, R> Detector<F, Peak<R>>
+where
+    F: Frame,
+    R: peak::Rectifier<F>,
+{
+    /// Construct a new **Peak** **Detector** that uses the given rectifier.
+    pub fn peak_from_rectifier(rectifier: R, attack_frames: f32, release_frames: f32) -> Self {
+        let peak = rectifier.into();
+        Self::new(peak, attack_frames, release_frames)
+    }
+}
+
+impl<F> Detector<F, Peak<peak::FullWave>>
+where
+    F: Frame,
+{
+    /// Construct a new full wave **Peak** **Detector**.
+    pub fn peak(attack_frames: f32, release_frames: f32) -> Self {
+        let peak = Peak::full_wave();
+        Self::new(peak, attack_frames, release_frames)
+    }
+}
+
+impl<F> Detector<F, Peak<peak::PositiveHalfWave>>
+where
+    F: Frame,
+{
+    /// Construct a new positive half wave **Peak** **Detector**.
+    pub fn peak_positive_half_wave(attack_frames: f32, release_frames: f32) -> Self {
+        let peak = Peak::positive_half_wave();
+        Self::new(peak, attack_frames, release_frames)
+    }
+}
+
+impl<F> Detector<F, Peak<peak::NegativeHalfWave>>
+where
+    F: Frame,
+{
+    /// Construct a new positive half wave **Peak** **Detector**.
+    pub fn peak_negative_half_wave(attack_frames: f32, release_frames: f32) -> Self {
+        let peak = Peak::negative_half_wave();
+        Self::new(peak, attack_frames, release_frames)
+    }
+}
+
+impl<F, D> Detector<F, D>
+where
+    F: Frame,
+    D: Detect<F>,
+{
+    fn new(detect: D, attack_frames: f32, release_frames: f32) -> Self {
+        Detector {
+            last_env_frame: D::Output::equilibrium(),
+            attack_gain: calc_gain(attack_frames),
+            release_gain: calc_gain(release_frames),
+            detect: detect,
+        }
+    }
+
+    /// Set the **Detector**'s attack time as a number of frames.
+    pub fn set_attack_frames(&mut self, frames: f32) {
+        self.attack_gain = calc_gain(frames);
+    }
+
+    /// Set the **Detector**'s release time as a number of frames.
+    pub fn set_release_frames(&mut self, frames: f32) {
+        self.attack_gain = calc_gain(frames);
+    }
+
+    /// Given the next input signal frame, detect and return the next envelope frame.
+    pub fn next(&mut self, frame: F) -> D::Output {
+        let Detector {
+            attack_gain,
+            release_gain,
+            ref mut detect,
+            ref mut last_env_frame,
+        } = *self;
+
+        let detected_frame = detect.detect(frame);
+        let new_env_frame = last_env_frame.zip_map(detected_frame, |l, d| {
+            let gain = if l < d { attack_gain } else { release_gain };
+            let diff = l.add_amp(-d.to_signed_sample());
+            d.add_amp(diff.mul_amp(gain.to_sample()).to_sample())
+        });
+        *last_env_frame = new_env_frame;
+        new_env_frame
+    }
+}

--- a/src/envelope/mod.rs
+++ b/src/envelope/mod.rs
@@ -1,0 +1,3 @@
+pub mod detect;
+
+pub use self::detect::{Detect, Detector};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub use types::{I24, U24, I48, U48};
 
 pub mod slice;
 pub mod conv;
+pub mod envelope;
 pub mod frame;
 pub mod peak;
 pub mod ring_buffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,15 @@ mod ops {
         pub fn sqrt(x: f32) -> f32 {
             x.sqrt()
         }
+
+        #[cfg(feature = "std")]
+        pub fn powf32(a: f32, b: f32) -> f32 {
+            a.powf(b)
+        }
+        #[cfg(not(feature = "std"))]
+        pub fn powf32(a: f32, b: f32) -> f32 {
+            unsafe { core::intrinsics::powf32(a, b) }
+        }
     }
 
     pub mod f64 {

--- a/src/peak.rs
+++ b/src/peak.rs
@@ -2,6 +2,21 @@
 
 use {Frame, Sample};
 
+/// A signal rectifier that produces the absolute amplitude from samples.
+pub fn full_wave<F>(frame: F) -> F::Signed
+where
+    F: Frame,
+{
+    frame.map(|s| {
+        let signed = s.to_signed_sample();
+        if signed < Sample::equilibrium() {
+            -signed
+        } else {
+            signed
+        }
+    })
+}
+
 /// A signal rectifier that produces only the positive samples.
 pub fn positive_half_wave<F>(frame: F) -> F
 where
@@ -27,16 +42,52 @@ where
 }
 
 /// A signal rectifier that produces the absolute amplitude from samples.
-pub fn full_wave<F>(frame: F) -> F
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct FullWave;
+/// A signal rectifier that produces only the positive samples.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct PositiveHalfWave;
+/// A signal rectifier that produces only the negative samples.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct NegativeHalfWave;
+
+/// Types that may be used to rectify a signal of frames `F` for a `Peak` detector.
+pub trait Rectifier<F>
 where
     F: Frame,
 {
-    frame.map(|s| {
-        let signed = s.to_signed_sample();
-        if signed < Sample::equilibrium() {
-            -signed
-        } else {
-            signed
-        }.to_sample()
-    })
+    /// Frames that can be detected.
+    type Output: Frame<NumChannels=F::NumChannels>;
+    /// Rectify the given frame.
+    fn rectify(&mut self, frame: F) -> Self::Output;
+}
+
+impl<F> Rectifier<F> for FullWave
+where
+    F: Frame,
+{
+    type Output = F::Signed;
+    fn rectify(&mut self, frame: F) -> Self::Output {
+        full_wave(frame)
+    }
+}
+
+impl<F> Rectifier<F> for PositiveHalfWave
+where
+    F: Frame,
+{
+    type Output = F;
+    fn rectify(&mut self, frame: F) -> Self::Output {
+        positive_half_wave(frame)
+    }
+}
+
+impl<F> Rectifier<F> for NegativeHalfWave
+where
+    F: Frame,
+{
+    type Output = F;
+    fn rectify(&mut self, frame: F) -> Self::Output {
+        negative_half_wave(frame)
+    }
 }

--- a/src/peak.rs
+++ b/src/peak.rs
@@ -57,7 +57,7 @@ where
     F: Frame,
 {
     /// Frames that can be detected.
-    type Output: Frame<NumChannels=F::NumChannels>;
+    type Output: Frame<NumChannels = F::NumChannels>;
     /// Rectify the given frame.
     fn rectify(&mut self, frame: F) -> Self::Output;
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -2648,10 +2648,7 @@ where
 
     /// Consumes `Self` and returns the inner signal `S` and `Detector`.
     pub fn into_parts(self) -> (S, envelope::Detector<S::Frame, D>) {
-        let DetectEnvelope {
-            signal,
-            detector,
-        } = self;
+        let DetectEnvelope { signal, detector } = self;
         (signal, detector)
     }
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -22,6 +22,7 @@
 
 use {BTreeMap, Duplex, Frame, Sample, Rc, VecDeque, Box};
 use core;
+use envelope;
 use interpolate::{Converter, Interpolator};
 use ring_buffer;
 use rms;
@@ -656,6 +657,8 @@ pub trait Signal {
     ///
     /// The window size of the RMS detector is equal to the given ring buffer length.
     ///
+    /// # Example
+    ///
     /// ```
     /// extern crate sample;
     ///
@@ -681,6 +684,41 @@ pub trait Signal {
         Rms {
             signal: self,
             rms: rms::Rms::new(ring_buffer),
+        }
+    }
+
+    /// An adaptor that detects and yields the envelope of the signal.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// extern crate sample;
+    ///
+    /// use sample::{envelope, signal, Signal};
+    ///
+    /// fn main() {
+    ///     let signal = signal::rate(4.0).const_hz(1.0).sine();
+    ///     let attack = 1.0;
+    ///     let release = 1.0;
+    ///     let detector = envelope::Detector::peak(attack, release);
+    ///     let mut envelope = signal.detect_envelope(detector);
+    ///     assert_eq!(
+    ///         envelope.take(4).collect::<Vec<_>>(),
+    ///         vec![[0.0], [0.6321205496788025], [0.23254416035257117], [0.7176687675647109]]
+    ///     );
+    /// }
+    /// ```
+    fn detect_envelope<D>(
+        self,
+        detector: envelope::Detector<Self::Frame, D>,
+    ) -> DetectEnvelope<Self, D>
+    where
+        Self: Sized,
+        D: envelope::Detect<Self::Frame>,
+    {
+        DetectEnvelope {
+            signal: self,
+            detector: detector,
         }
     }
 
@@ -1029,6 +1067,17 @@ where
 {
     signal: S,
     rms: rms::Rms<S::Frame, D>,
+}
+
+/// An adaptor that detects and yields the envelope of the signal.
+#[derive(Clone)]
+pub struct DetectEnvelope<S, D>
+where
+    S: Signal,
+    D: envelope::Detect<S::Frame>,
+{
+    signal: S,
+    detector: envelope::Detector<S::Frame, D>,
 }
 
 
@@ -2579,5 +2628,41 @@ where
     type Frame = <S::Frame as Frame>::Float;
     fn next(&mut self) -> Self::Frame {
         self.rms.next(self.signal.next())
+    }
+}
+
+impl<S, D> DetectEnvelope<S, D>
+where
+    S: Signal,
+    D: envelope::Detect<S::Frame>,
+{
+    /// Set the **Detector**'s attack time as a number of frames.
+    pub fn set_attack_frames(&mut self, frames: f32) {
+        self.detector.set_attack_frames(frames);
+    }
+
+    /// Set the **Detector**'s release time as a number of frames.
+    pub fn set_release_frames(&mut self, frames: f32) {
+        self.detector.set_release_frames(frames);
+    }
+
+    /// Consumes `Self` and returns the inner signal `S` and `Detector`.
+    pub fn into_parts(self) -> (S, envelope::Detector<S::Frame, D>) {
+        let DetectEnvelope {
+            signal,
+            detector,
+        } = self;
+        (signal, detector)
+    }
+}
+
+impl<S, D> Signal for DetectEnvelope<S, D>
+where
+    S: Signal,
+    D: envelope::Detect<S::Frame>,
+{
+    type Frame = D::Output;
+    fn next(&mut self) -> Self::Frame {
+        self.detector.next(self.signal.next())
     }
 }


### PR DESCRIPTION
Envelope detection (also known as envelope following) is commonly used
in audio for monitoring, side-chaining, etc.

`Detector` is generic over its `Detect`ion type and also allows for
specifying `attack` and `release`. Implementations of `Detect` are
provided for both RMS and peak detection.

An accompanying `Signal::detect_envelope` method has been added that
produces an adaptor yielding detected envelope frames.