### PR TITLE
Publish 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.8.1"
+version = "0.9.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]


### PR DESCRIPTION
Breaking Changes:

- #87 `Signal::is_exhausted` and `Signal::until_exhausted` added. Slight
breakage as `FromIterator` and `FromInterleavedSamplesIterator` have
slightly different sizes.

Non-breaking Changes:

- #85 `ring_buffer::Bounded::drain`
- #90 `ring_buffer::Bounded::is_empty`
- #91 `Signal::fork`
- #92 `Rms::current`. Adds examples to `Rms` docs.