### PR TITLE
Publish version 0.10.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample"
 description = "A crate providing the fundamentals for working with audio PCM DSP."
-version = "0.9.1"
+version = "0.10.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 readme = "README.md"
 keywords = ["dsp", "bit-depth", "rate", "pcm", "audio"]

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1984,7 +1984,7 @@ impl Rate {
     /// use sample::{signal, Signal};
     /// 
     /// fn main() {
-    ///     let step = signal::rate(4.0).hz(1.0, signal::gen(|| [1.0]));
+    ///     let step = signal::rate(4.0).hz(signal::gen(|| [1.0]));
     ///     let mut phase = signal::phase(step);
     ///     assert_eq!(phase.next(), [0.0]);
     ///     assert_eq!(phase.next(), [0.25]);
@@ -1994,7 +1994,7 @@ impl Rate {
     ///     assert_eq!(phase.next(), [0.25]);
     /// }
     /// ```
-    pub fn hz<S>(self, init: f64, hz: S) -> Hz<S>
+    pub fn hz<S>(self, hz: S) -> Hz<S>
     where
         S: Signal<Frame = [f64; 1]>,
     {

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -23,7 +23,7 @@ macro_rules! test_type {
             #[should_panic]
             fn add_panic_debug() {
                 use sample::types::$mod_name::{self, $T};
-                $mod_name::MAX + $T::new(1).unwrap();
+                let _ = $mod_name::MAX + $T::new(1).unwrap();
             }
 
             #[cfg(debug_assertions)]
@@ -31,7 +31,7 @@ macro_rules! test_type {
             #[should_panic]
             fn sub_panic_debug() {
                 use sample::types::$mod_name::{self, $T};
-                $mod_name::MIN - $T::new(1).unwrap();
+                let _ = $mod_name::MIN - $T::new(1).unwrap();
             }
 
             #[cfg(debug_assertions)]
@@ -39,7 +39,7 @@ macro_rules! test_type {
             #[should_panic]
             fn mul_panic_debug() {
                 use sample::types::$mod_name::{self, $T};
-                $mod_name::MAX * $T::new(2).unwrap();
+                let _ = $mod_name::MAX * $T::new(2).unwrap();
             }
 
             #[cfg(not(debug_assertions))]


### PR DESCRIPTION
Includes:

- Derive clone for `signal::Fork`.
- Convert the `hz` method to take a `Signal` rather than an `Iterator`.
- Remove unnecessary arg from `Rate::hz`.